### PR TITLE
This commit fixes #14.

### DIFF
--- a/include/comet/Dialect/IndexTree/Transforms/IterationDomain.h
+++ b/include/comet/Dialect/IndexTree/Transforms/IterationDomain.h
@@ -65,7 +65,6 @@ class IterDomain
   IterDomain *right = nullptr;
 
 public:
-  static std::vector<unique_ptr<IterDomain>> domains;
   static IterDomain *makeDomain(Tensor *tensor, int dim);
 
   IterDomain(Tensor *tensor, int dim) : tensor(tensor), dim(dim){};

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -52,7 +52,7 @@ using namespace mlir::tensorAlgebra;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif
@@ -60,7 +60,6 @@ using namespace mlir::tensorAlgebra;
 
 using namespace mlir;
 
-unique_ptr<Index_Tree> tree;
 namespace
 {
 
@@ -147,7 +146,7 @@ IndicesType getUnion(IndicesType indices1, IndicesType indices2)
   return allIndices;
 }
 
-void doTensorMultOp(TensorMultOp op)
+void doTensorMultOp(TensorMultOp op, unique_ptr<Index_Tree>& tree)
 {
   Value rhs1_tensor = getRealRhs(op.getRhs1().getDefiningOp());
   Value rhs2_tensor = getRealRhs(op.getRhs2().getDefiningOp());
@@ -208,7 +207,7 @@ void doTensorMultOp(TensorMultOp op)
 }
 
 template <typename T>
-void doElementWiseOp(T op)
+void doElementWiseOp(T op, unique_ptr<Index_Tree>& tree)
 {
   Value rhs1_tensor = getRealRhs(op.getRhs1().getDefiningOp());
   Value rhs2_tensor = getRealRhs(op.getRhs2().getDefiningOp());
@@ -431,7 +430,7 @@ void treeToDialect(Index_Tree *tree)
 
 void LowerTensorAlgebraToIndexTreePass::runOnOperation()
 {
-  assert(tree == nullptr);
+  unique_ptr<Index_Tree> tree;
   func::FuncOp func = getOperation();
 
   tree = Index_Tree::createTreeWithRoot();
@@ -444,12 +443,12 @@ void LowerTensorAlgebraToIndexTreePass::runOnOperation()
     {
       if (isa<TensorMultOp>(&op))
       {
-        doTensorMultOp(cast<TensorMultOp>(&op));
+        doTensorMultOp(cast<TensorMultOp>(&op), tree);
         formIndexTreeDialect = true;
       }
       else if (isa<TensorElewsMultOp>(&op))
       {
-        doElementWiseOp<TensorElewsMultOp>(cast<TensorElewsMultOp>(&op));
+        doElementWiseOp<TensorElewsMultOp>(cast<TensorElewsMultOp>(&op), tree);
         formIndexTreeDialect = true;
       }
       else if (isa<TensorAddOp>(&op) || isa<TensorSubtractOp>(&op))
@@ -457,12 +456,12 @@ void LowerTensorAlgebraToIndexTreePass::runOnOperation()
         // elementwise addition and subtraction
         if (isa<TensorAddOp>(&op))
         {
-          doElementWiseOp<TensorAddOp>(cast<TensorAddOp>(&op));
+          doElementWiseOp<TensorAddOp>(cast<TensorAddOp>(&op), tree);
         }
 
         if (isa<TensorSubtractOp>(&op))
         {
-          doElementWiseOp<TensorSubtractOp>(cast<TensorSubtractOp>(&op));
+          doElementWiseOp<TensorSubtractOp>(cast<TensorSubtractOp>(&op), tree);
         }
         formIndexTreeDialect = true;
       }

--- a/lib/Conversion/TensorAlgebraToSCF/EarlyLowering.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/EarlyLowering.cpp
@@ -43,7 +43,6 @@
 #include <map>
 #include <set>
 #include <unordered_map>
-
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
@@ -69,7 +68,7 @@ using namespace mlir::indexTree;
   llvm::errs() << __FILE__ << ":" << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif
@@ -1620,7 +1619,8 @@ namespace
                     ConversionPatternRewriter &rewriter) const final
     {
       // We only lower the main function as we expect that all other functions
-      // have been inlined.
+      // have been inlined. 
+      // [TODO] Make sure this is indeed the case
       if (op.getName() != "main")
         return failure();
 

--- a/lib/Conversion/TensorAlgebraToSCF/LateLowering.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/LateLowering.cpp
@@ -36,7 +36,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/Sequence.h"
 #include "mlir/IR/BuiltinOps.h"
-
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/IR/Matchers.h"
@@ -61,7 +60,7 @@ using namespace mlir::tensorAlgebra;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif
@@ -282,11 +281,17 @@ void LateLoweringPass::runOnOperation()
 {
   func::FuncOp function = getOperation();
 
-  //  Verify that the given main has no inputs and results.
-  if (function.getNumArguments() || function.getFunctionType().getNumResults())
+  // Removing this check COMET will fail to lower source with functions other than
+  // main. However, this is in contrast with the assumption in EarlyLowering.cpp
+  // that all functions have been inlined.
+  if (function.getName() == "main")
   {
-    function.emitError("expected 'main' to have 0 inputs and 0 results");
-    return signalPassFailure();
+    //  Verify that the given main has no inputs and results.
+    if (function.getNumArguments() || function.getFunctionType().getNumResults())
+    {
+      function.emitError("expected 'main' to have 0 inputs and 0 results");
+      return signalPassFailure();
+    }
   }
 
   // The first thing to define is the conversion target. This will define the

--- a/lib/Conversion/TensorAlgebraToSCF/LowerFunc.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/LowerFunc.cpp
@@ -1,4 +1,3 @@
-
 #include "mlir/IR/BuiltinDialect.h"
 #include "comet/Dialect/TensorAlgebra/IR/TADialect.h"
 #include "comet/Dialect/TensorAlgebra/Passes.h"

--- a/lib/Conversion/TensorAlgebraToSCF/LowerPCToLoops.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/LowerPCToLoops.cpp
@@ -62,7 +62,7 @@ using namespace mlir::indexTree;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Conversion/TensorAlgebraToSCF/TensorAlgebraToSCF.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/TensorAlgebraToSCF.cpp
@@ -38,7 +38,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/Sequence.h"
-
 #include "mlir/IR/BuiltinOps.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -65,7 +64,7 @@ using namespace mlir::tensorAlgebra;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif
@@ -704,12 +703,15 @@ namespace
 void LowerTensorAlgebraToSCFPass::runOnOperation()
 {
   mlir::func::FuncOp function = getOperation();
-
-  //  Verify that the given main has no inputs and results.
-  if (function.getNumArguments() || function.getFunctionType().getNumResults())
+  
+  if (function.getName() == "main")
   {
-    function.emitError("expected 'main' to have 0 inputs and 0 results");
-    return signalPassFailure();
+    //  Verify that the given main has no inputs and results.
+    if (function.getNumArguments() || function.getFunctionType().getNumResults())
+    {
+      function.emitError("expected 'main' to have 0 inputs and 0 results");
+      return signalPassFailure();
+    }
   }
 
   // The first thing to define is the conversion target. This will define the

--- a/lib/Dialect/IndexTree/IR/IndexTree.cpp
+++ b/lib/Dialect/IndexTree/IR/IndexTree.cpp
@@ -43,7 +43,7 @@ using namespace std;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/IndexTree/Transforms/Fusion.cpp
+++ b/lib/Dialect/IndexTree/Transforms/Fusion.cpp
@@ -90,7 +90,7 @@ using llvm::StringRef;
   llvm::errs() << __FILE__ << ":" << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/IndexTree/Transforms/IterationDomain.cpp
+++ b/lib/Dialect/IndexTree/Transforms/IterationDomain.cpp
@@ -23,8 +23,9 @@
 #include "comet/Dialect/IndexTree/Transforms/Tensor.h"
 
 using namespace std;
-
-std::vector<unique_ptr<IterDomain>> IterDomain::domains;
+// Since multiple threads can lower different functions,
+// we need one for each thread lowering.
+thread_local std::vector<unique_ptr<IterDomain>> domains;
 
 IterDomain *IterDomain::makeDomain(Tensor *tensor, int dim)
 {

--- a/lib/Dialect/IndexTree/Transforms/UnitExpression.cpp
+++ b/lib/Dialect/IndexTree/Transforms/UnitExpression.cpp
@@ -41,7 +41,7 @@ using std::vector;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
+++ b/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
@@ -84,7 +84,7 @@ using llvm::StringRef;
   llvm::errs() << __FILE__ << ":" << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/TensorAlgebra/Transforms/CheckImplicitTensorDecls.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/CheckImplicitTensorDecls.cpp
@@ -61,7 +61,7 @@ using namespace mlir::tensorAlgebra;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/TensorAlgebra/Transforms/LinalgTransforms.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/LinalgTransforms.cpp
@@ -57,7 +57,7 @@ using namespace mlir::tensorAlgebra;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif
@@ -479,7 +479,7 @@ namespace
       RewritePatternSet patterns(&getContext());
 
       // Add the patterns to the list lower linalg fill operation
-      patterns.insert<LinalgLoweringPattern<FillOp>>(ctx, LinalgLoweringType::Loops);
+      patterns.insert<mlir::LinalgLoweringPattern<FillOp>>(ctx, LinalgLoweringType::Loops);
       (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
     }
   };

--- a/lib/Dialect/TensorAlgebra/Transforms/Passes.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/Passes.cpp
@@ -18,7 +18,6 @@
 // GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 
 // TODO(gkestor): check these header files
 #include "mlir/Pass/Pass.h"
@@ -84,7 +83,7 @@ using namespace tensorAlgebra;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/TensorAlgebra/Transforms/TensorDeclLowering.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/TensorDeclLowering.cpp
@@ -70,7 +70,8 @@ using namespace mlir::indexTree;
   llvm::errs() << __FILE__ << ":" << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
+// #define comet_debug() llvm::nulls()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/TensorAlgebra/Transforms/Transforms.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/Transforms.cpp
@@ -74,7 +74,7 @@ using namespace mlir::indexTree;
   llvm::errs() << __FILE__ << " " << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif

--- a/lib/Dialect/Utils/Utils.cpp
+++ b/lib/Dialect/Utils/Utils.cpp
@@ -57,7 +57,7 @@
   llvm::errs() << __FILE__ << ":" << __LINE__ << " "; \
   n.dump()
 #else
-#define comet_debug() llvm::nulls()
+#define comet_debug() if(true){}else llvm::errs()
 #define comet_pdump(n)
 #define comet_vdump(n)
 #endif


### PR DESCRIPTION
Made changes to allow COMET to lower multiple functions in a source file. Main issue was that multithreading is automatically used for different functions, causing unsafe concurrent access to global structures. Also, functions with input arguments  failed to lower.
This fix includes two main modifications:

1) Removed global structures where possible or made thread_local, otherwise. 
2) Certain parts of the code expect that any functions have been inlined and only main is available, thus expecting no input arguments. However, this is not the case. Modified code to avoid this assumption.