### PR TITLE
Fix redundant traspose in TCtoTTGT pass

### DIFF
--- a/lib/Dialect/TensorAlgebra/Transforms/TCtoTTGT.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/TCtoTTGT.cpp
@@ -421,8 +421,11 @@ namespace
             MemRefType::get(lhsDims, lhsMemrefType.getElementType()), loc,
             rewriter);
         useLHSTranspose = true;
+        Value constantOp = rewriter.create<ConstantOp>(loc, rewriter.getF64FloatAttr(0.0));
+
+        rewriter.create<linalg::FillOp>(loc, constantOp, lhsAlloc);
         // TODO(gkestor): we might need this copy if we support update C[] += A[] * B[]
-        rewriter.create<linalg::TransposeOp>(loc, lhsMemref, lhsAlloc, llvm::ArrayRef<int64_t>(lhsOutPerm_int64));
+        // rewriter.create<linalg::TransposeOp>(loc, lhsMemref, lhsAlloc, llvm::ArrayRef<int64_t>(lhsOutPerm_int64));
       }
 
       RankedTensorType collapsedTensorType;

--- a/lib/Dialect/TensorAlgebra/Transforms/TCtoTTGT.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/TCtoTTGT.cpp
@@ -421,11 +421,17 @@ namespace
             MemRefType::get(lhsDims, lhsMemrefType.getElementType()), loc,
             rewriter);
         useLHSTranspose = true;
-        Value constantOp = rewriter.create<ConstantOp>(loc, rewriter.getF64FloatAttr(0.0));
+        double beta_val = betaAttr.cast<FloatAttr>().getValueAsDouble();
 
-        rewriter.create<linalg::FillOp>(loc, constantOp, lhsAlloc);
-        // TODO(gkestor): we might need this copy if we support update C[] += A[] * B[]
-        // rewriter.create<linalg::TransposeOp>(loc, lhsMemref, lhsAlloc, llvm::ArrayRef<int64_t>(lhsOutPerm_int64));
+        if(beta_val == 0)
+        {
+          Value constantOp = rewriter.create<ConstantOp>(loc, rewriter.getF64FloatAttr(0.0));
+          rewriter.create<linalg::FillOp>(loc, constantOp, lhsAlloc);
+        }
+        else
+        {
+          rewriter.create<linalg::TransposeOp>(loc, lhsMemref, lhsAlloc, llvm::ArrayRef<int64_t>(lhsOutPerm_int64));
+        }
       }
 
       RankedTensorType collapsedTensorType;


### PR DESCRIPTION
When one or more tensors are transposed before a contraction (C=A*B), the shape of the contraction result might be different than the expected output C. Thus this intermediate results is stored in a temporary tensor, which will later be tranposed in the C, taking the expected shape.
However, instead of just allocating this intermediate tensor we would also transpose tensor C into it, making
a redundant trasposition.  This transposition is only needed in the case of C (+=,-= ) A* B.