### PR TITLE
Added a new attribute iterator_type to IndexNode

### DIFF
--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -96,8 +96,10 @@ def IndexTreeIndicesOp : IndexTree_Op<"Indices", [Pure]>{
   let summary = "";
   let description = [{
   }];
-
-  let arguments = (ins Variadic<AnyType>:$children, ArrayAttr:$indices);
+  // Added `iterator_type` to the IndexTreeIndicesOp. It is analogous the `iterator_types` in the `linalg.generic` op.
+  // Candidate options: parallel, reduction, window, serial, default. What options should support needs further consideration.
+  // References: https://mlir.llvm.org/docs/Dialects/Linalg/#linalggeneric-linalggenericop
+  let arguments = (ins Variadic<AnyType>:$children, ArrayAttr:$indices, StrAttr:$iterator_type);
   let results = (outs I64:$output);
 
    //TODO(gkestor): add verifier

--- a/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
+++ b/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
@@ -753,8 +753,8 @@ namespace
           // else
           { /// m comes from the load
             comet_debug() << " DIFFERENT:Parent and Child has the different alloc\n";
-            comet_vdump(alloc_parent_bounds);
-            comet_vdump(alloc_child_bounds);
+            // comet_vdump(alloc_parent_bounds);
+            // comet_vdump(alloc_child_bounds);
             index_lower = parent_accessIdx;
           }
         }
@@ -4376,7 +4376,7 @@ void LowerIndexTreeToSCFPass::doLoweringIndexTreeToSCF(indexTree::IndexTreeOp &r
                      formats /* output */);
 
       comet_debug() << " indices.size(): " << indices.size() << " tensors.size(): " << tensors.size() << "\n";
-      for (unsigned int m = 0; m < tensors.size(); m++)
+      for ([[maybe_unused]] unsigned int m = 0; m < tensors.size(); m++)
       {
         comet_debug() << " Formats:" << formats[m] << " " << ids[m] << " ";
         comet_vdump(tensors[m]);

--- a/lib/Conversion/TensorAlgebraToSCF/LowerPCToLoops.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/LowerPCToLoops.cpp
@@ -171,7 +171,7 @@ void PCToLoopsLoweringPass::replicateOpsForLoopBody(Location loc, OpBuilder &bui
   if (isa<indexTree::IndexTreeIndicesOp>(op) && indices != NULL)
   {
     indexTree::IndexTreeIndicesOp it_indices_op = llvm::dyn_cast<indexTree::IndexTreeIndicesOp>(op);
-    Value indices_op_new = builder.create<indexTree::IndexTreeIndicesOp>(loc, i64Type, indices, it_indices_op.getIndices());
+    Value indices_op_new = builder.create<indexTree::IndexTreeIndicesOp>(loc, i64Type, indices, it_indices_op.getIndices(), it_indices_op.getIteratorType());
 
     indices = indices_op_new; /// for subsequent IndexTreeIndicesOp creation
   }
@@ -180,7 +180,7 @@ void PCToLoopsLoweringPass::replicateOpsForLoopBody(Location loc, OpBuilder &bui
   if (isa<indexTree::IndexTreeIndicesOp>(op) && compute != NULL && indices == NULL)
   {
     indexTree::IndexTreeIndicesOp it_indices_op = llvm::dyn_cast<indexTree::IndexTreeIndicesOp>(op);
-    indices = builder.create<indexTree::IndexTreeIndicesOp>(loc, i64Type, compute, it_indices_op.getIndices());
+    indices = builder.create<indexTree::IndexTreeIndicesOp>(loc, i64Type, compute, it_indices_op.getIndices(), it_indices_op.getIteratorType());
   }
 
   if (isa<indexTree::IndexTreeOp>(op) && indices != NULL)

--- a/lib/Dialect/IndexTree/IR/IndexTree.cpp
+++ b/lib/Dialect/IndexTree/IR/IndexTree.cpp
@@ -249,3 +249,16 @@ vector<mlir::Operation *> Index_Tree::getContainingTAOps()
   }
   return ops;
 }
+
+std::unordered_set<std::string> IteratorType::supported_types = {"default",
+                                                                 "serial",
+                                                                 "parallel",
+                                                                 "reduction",
+                                                                 "window"};
+void IteratorType::setType(std::string t) {
+  if (supported_types.find(t) != supported_types.end()) {
+    type = t;
+  } else {
+    llvm::errs() << "Unsupported iterator type " + t + "\n";
+  }
+}

--- a/lib/Dialect/IndexTree/Transforms/Fusion.cpp
+++ b/lib/Dialect/IndexTree/Transforms/Fusion.cpp
@@ -803,19 +803,25 @@ mlir::Value createResetIndicesOps(
     if (index == bound_index)
     {
       /// The IndicesOp node closest to the ComputeOp node
+      /// TODO(zhen.peng): new attribute iterator_type
+      auto dumb_iterator_type = builder.getStringAttr("default");
       indices_op = builder.create<indexTree::IndexTreeIndicesOp>(
           loc,
           i64_type,
           compute_op,
-          indices_attr);
+          indices_attr,
+          dumb_iterator_type);
     }
     else
     {
+      /// TODO(zhen.peng): new attribute iterator_type
+      auto dumb_iterator_type = builder.getStringAttr("default");
       indices_op = builder.create<indexTree::IndexTreeIndicesOp>(
           loc,
           i64_type,
           last_indices_op,
-          indices_attr);
+          indices_attr,
+          dumb_iterator_type);
     }
     last_indices_op = indices_op;
   }

--- a/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
+++ b/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
@@ -243,7 +243,9 @@ void splitIndicesOp(Operation *needSplitNode, Value denseIndicesOp, OpBuilder &b
         comet_vdump(indicesOp.getOperation()->getOperand(i));
         comet_vdump(operands[i]);
         auto i64Type = builder.getI64Type();
-        Value t1 = builder.create<indexTree::IndexTreeIndicesOp>(loc, i64Type, operands[i], indices);
+        /// TODO(zhen.peng): new attribute iterator_type
+        auto dumb_iterator_type = builder.getStringAttr("default");
+        Value t1 = builder.create<indexTree::IndexTreeIndicesOp>(loc, i64Type, operands[i], indices, dumb_iterator_type);
 
         comet_debug() << "New IndexTreeIndicesOp added:\n";
         comet_vdump(t1);


### PR DESCRIPTION
1. Added to `IndexTreeIndicesOp` (Index Tree Dialect) a new attribute `iterator_type` to tell if the iteration can be parallelized. It is analogous to `iterator_types` in the `linalg.generic` op (https://mlir.llvm.org/docs/Dialects/Linalg/#linalggeneric-linalggenericop). Candidate options: parallel, reduction, window, serial, default. This change influences many other code where `builder.createindexTree::IndexTreeIndicesOp` is called as follows. Some places may need further change to make the logic correct. 
    1. `lib/Conversion/TensorAlgebraToSCF/LowerPCToLoops.cpp` 
    2. `lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp` 
    3. `lib/Dialect/IndexTree/Transforms/Fusion.cpp` 
    4. `lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp`
2. Added a helper class `IteratorType` as the handle to the new attribute `iterator_type` and a member in the class `TreeNode` (`include/comet/Dialect/IndexTree/IR/IndexTree.h`).
3. Added a member `iteratorTypes` in the class `Index_Tree` to store the iterator type of each iterative index.