### PR TITLE
Fix semiring tests

### DIFF
--- a/include/comet/Dialect/IndexTree/IR/IndexTreeDialect.h
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeDialect.h
@@ -61,7 +61,7 @@ namespace mlir
 {
     namespace indexTree
     {
-        static const llvm::StringSet<> Semiring_intersectOps{"land", "times", "pairxy"};
+        static const llvm::StringSet<> Semiring_intersectOps{"land", "times", "pairxy", "first", "second", "plusxy", "minus"};
     }
 }
 

--- a/include/comet/Dialect/TensorAlgebra/IR/TAOps.td
+++ b/include/comet/Dialect/TensorAlgebra/IR/TAOps.td
@@ -1060,7 +1060,8 @@ def TensorExtractOp : TA_Op<"TAExtractOp", [Pure, SameVariadicOperandSize]>{
 
   let arguments = (
     ins TA_AnyTensor:$tensor, 
-    Index:$pos
+    Index:$pos,
+    F64Attr:$zero
   );
 
   let results = (outs AnyFloat);

--- a/integration_test/ops/eltwise_add_CSRxCSR_oCSR.ta
+++ b/integration_test/ops/eltwise_add_CSRxCSR_oCSR.ta
@@ -29,7 +29,7 @@ def main() {
 # CHECK: data = 
 # CHECK-NEXT: 5,
 # CHECK-NEXT: data = 
-# CHECK-NEXT: 0,
+# CHECK-NEXT: -1,
 # CHECK-NEXT: data = 
 # CHECK-NEXT: 0,2,4,5,7,9,
 # CHECK-NEXT: data = 

--- a/integration_test/ops/eltwise_subtract_CSRxCSR_oCSR.ta
+++ b/integration_test/ops/eltwise_subtract_CSRxCSR_oCSR.ta
@@ -29,7 +29,7 @@ def main() {
 # CHECK: data = 
 # CHECK-NEXT: 5,
 # CHECK-NEXT: data = 
-# CHECK-NEXT: 0,
+# CHECK-NEXT: -1,
 # CHECK-NEXT: data = 
 # CHECK-NEXT: 0,2,4,5,7,9,
 # CHECK-NEXT: data = 

--- a/integration_test/semiring/eltwise_monoidPlus_COOxDense_oCOO.ta
+++ b/integration_test/semiring/eltwise_monoidPlus_COOxDense_oCOO.ta
@@ -27,7 +27,7 @@ def main() {
 # CHECK-NEXT: data = 
 # CHECK-NEXT: 0,0,1,1,2,3,3,4,4,
 # CHECK-NEXT: data = 
-# CHECK-NEXT: 0,
+# CHECK-NEXT: -1,
 # CHECK-NEXT: data = 
 # CHECK-NEXT: 0,3,1,4,2,0,3,1,4,
 # CHECK-NEXT: data = 

--- a/lib/Conversion/TensorAlgebraToSCF/SparseTensorConversionPass.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/SparseTensorConversionPass.cpp
@@ -633,10 +633,10 @@ class ConvertWorkspaceTensorExtractOp
         Value extracted = builder.create<tensor::ExtractOp>(loc, op->getResultTypes(), workspace.workspace, pos);
         builder.create<scf::YieldOp>(loc, ArrayRef<Value>({extracted}));
       },
-      [op] (OpBuilder& builder, Location loc) {
+      [&] (OpBuilder& builder, Location loc) {
         // TODO: Does the zero value depend on the semi-ring?
         Type result_type  = op->getResult(0).getType();
-        Value zero = builder.create<arith::ConstantOp>(loc, result_type, builder.getFloatAttr(result_type, 0));
+        Value zero = builder.create<arith::ConstantOp>(loc, result_type, op.getZeroAttr());
         builder.create<scf::YieldOp>(loc, ArrayRef<Value>({zero}));
       }
     );


### PR DESCRIPTION
Added semiring operations to automatically assume same semantics as multiplication. This looks to fix the elementwise addition/subtraction as well but does not truly fix them. Requires #65 to be merged so that the new test case that causes elementwise addition to fail is also in this branch.  After these fixes, the test results I see are:

```
Failed Tests (9):
  COMET :: compound_exps/CSR_Dense_chain_mult_matrix.ta
  COMET :: compound_exps/CSR_mult_spTranspose_CSR.ta
  COMET :: compound_exps/spTranspose_CSR_eltwise_CSR.ta
  COMET :: compound_exps/spTranspose_CSR_mult_CSR.ta
  COMET :: kernels/triangleCount_SandiaLL.ta
  COMET :: kernels/triangleCount_SandiaLL_wMasking.ta
  COMET :: ops/eltwise_mult_DCSRxDense_oDCSR.ta
  COMET :: ops/mult_spgemm_CSRxCSR_oCSR_wMasking.ta
  COMET :: opts/opt_dense_transpose.ta


Testing Time: 1.45s

Total Discovered Tests: 136
  Unsupported:  15 (11.03%)
  Passed     : 112 (82.35%)
  Failed     :   9 (6.62%)
```