### PR TITLE
Decouple semiring attribute from domain inference

### DIFF
--- a/include/comet/Dialect/IndexTree/IR/IndexTreeDialect.h
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeDialect.h
@@ -57,13 +57,4 @@
 
 //===----------------------------------------------------------------------===//
 
-namespace mlir
-{
-    namespace indexTree
-    {
-        static const llvm::StringSet<> Semiring_intersectOps{"land", "times", "pairxy", "first", "second", "plusxy", "minus"};
-    }
-}
-
-
 #endif // INDEXTREE_DIALECT_H_

--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -128,8 +128,9 @@ def IndexTreeComputeOp : IndexTree_Op<"ComputeOp", [Pure]>{
   }];
 
   //TODO(gkestor): rethink the use of comp_worksp_opt, should we decouple that?
+  //TODO(alokvk2): Rename semiring to operation to account for elementwise addition
   /// MaskType attribute: {push, pull, auto, none}
-  let arguments = (ins IndexTree_NodeType:$parent, IndexTree_OperandType:$lhs, Variadic<IndexTree_OperandType>:$rhs, StrAttr:$semiring);
+  let arguments = (ins IndexTree_NodeType:$parent, IndexTree_OperandType:$lhs, Variadic<IndexTree_OperandType>:$rhs, StrAttr:$semiring, DefaultValuedAttr<BoolAttr, "false">:$compute_missing);
 
   let results = (outs TA_AnyTensor);
 

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -227,7 +227,8 @@ template<class TATensorOp>
 mlir::LogicalResult generalIndexOperationRewrite(
     mlir::Operation* op, 
     ArrayRef<mlir::Value> operands,
-    mlir::ConversionPatternRewriter &rewriter) {
+    mlir::ConversionPatternRewriter &rewriter,
+    bool compute_missing = false) {
 
   auto loc = op->getLoc();
   auto context = rewriter.getContext();
@@ -346,7 +347,8 @@ mlir::LogicalResult generalIndexOperationRewrite(
       parent,
       lhs_operand,
       rhs_operands,
-      rewriter.getStringAttr(semiring)
+      rewriter.getStringAttr(semiring),
+      rewriter.getBoolAttr(compute_missing)
   );
 
   rewriter.create<indexTree::YieldOp>(loc, TypeRange(), compute_op);
@@ -383,7 +385,7 @@ struct TensorAddOpLowering : public mlir::ConversionPattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op, ArrayRef<mlir::Value> operands,
                   mlir::ConversionPatternRewriter &rewriter) const final {
-    return generalIndexOperationRewrite<TensorAddOp>(op, operands, rewriter);
+    return generalIndexOperationRewrite<TensorAddOp>(op, operands, rewriter, true);
   }
 };
 
@@ -394,7 +396,7 @@ struct TensorSubtractOpLowering : public mlir::ConversionPattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op, ArrayRef<mlir::Value> operands,
                   mlir::ConversionPatternRewriter &rewriter) const final {
-    return generalIndexOperationRewrite<TensorSubtractOp>(op, operands, rewriter);
+    return generalIndexOperationRewrite<TensorSubtractOp>(op, operands, rewriter, true);
   }
 };
 

--- a/lib/Dialect/IndexTree/Transforms/IterationDomainInference.cpp
+++ b/lib/Dialect/IndexTree/Transforms/IterationDomainInference.cpp
@@ -74,7 +74,7 @@ struct InferIndexDomain : public OpRewritePattern<IndexTreeIndicesOp> {
       auto itComputeOp = cast<indexTree::IndexTreeComputeOp>(compute_op);
       auto semiringParts = itComputeOp.getSemiring().split('_');
 
-      if(!Semiring_intersectOps.contains(semiringParts.second)){
+      if(itComputeOp.getComputeMissing()){
         for(auto operand_op_val : itComputeOp.getRhs())
         {
           auto operand_op = operand_op_val.getDefiningOp();


### PR DESCRIPTION
Adding a new attribute to the index tree compute operation that determines whether or not to compute elements with only one element missing. For operations that use a semiring operation we do not want to do this. Mathematically, that is, any missing elements in a semiring operation are assumed to be the multiplicative annihilator. For elementwise addition and subtraction, we compute these elements.