### PR TITLE
Restructure scf conversion

### DIFF
--- a/frontends/comet_dsl/comet.cpp
+++ b/frontends/comet_dsl/comet.cpp
@@ -387,7 +387,6 @@ int loadAndProcessMLIR(mlir::MLIRContext &context,
     optPM.addPass(mlir::comet::createLowerTensorAlgebraToIndexTreePass(CodegenTarget));
 
     // Create new pass manager to optimize the index tree dialect
-    // mlir::OpPassManager &itOptPM = optPM.nest<IndexTreeOp>();
     optPM.addPass(mlir::comet::createIndexTreeDomainInferencePass());
 
     // if (OptKernelFusion)

--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -57,6 +57,7 @@ def IndexTreeOp : IndexTree_Op<"itree",
   let summary = "Create a scope for index tree iteration";
   let description = [{}];
 
+  let arguments = (ins Variadic<AnyType>:$inputs);
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>:$region);
 }
@@ -162,7 +163,7 @@ def ConcreteDomainInterface : OpInterface<"ConcreteDomain"> {
     the domain is fully-dscribed by it's arguments and does not rely on the
     the tensor definition to create the domain.
   }];
-  let cppNamespace = "::mlir::indexTree"; 
+  let cppNamespace = "::mlir::indexTree";
 
   let methods = [
     InterfaceMethod<[{

--- a/include/comet/Dialect/TensorAlgebra/IR/TAOps.td
+++ b/include/comet/Dialect/TensorAlgebra/IR/TAOps.td
@@ -1093,7 +1093,7 @@ def SpTensorGetVals : TA_Op<"SpTensorGetVals", [Pure]>{
 }
 
 def SpTensorGetCrd : TA_Op<"SpTensorGetCrd", [Pure]>{
-  let arguments = (ins TA_AnyTensor:$tensor, Index:$idx, OptionalAttr<I32Attr>:$dim);
+  let arguments = (ins TA_AnyTensor:$tensor, Index:$idx, I32Attr:$dim);
   let results = (outs Index:$crd);
 }
 

--- a/include/comet/Dialect/TensorAlgebra/IR/TAOps.td
+++ b/include/comet/Dialect/TensorAlgebra/IR/TAOps.td
@@ -1061,6 +1061,7 @@ def TensorExtractOp : TA_Op<"TAExtractOp", [Pure, SameVariadicOperandSize]>{
   let arguments = (
     ins TA_AnyTensor:$tensor, 
     Index:$pos,
+    Variadic<Index>:$crds,
     F64Attr:$zero
   );
 
@@ -1113,7 +1114,7 @@ def SpTensorGetNNZ : TA_Op<"SpTensorGetNNZ", [Pure]>{
 }
 
 def TensorFindPos : TA_Op<"TensorFindPos", [Pure]>{
-  let arguments = (ins TA_AnyTensor:$tensor, Index:$crd, I32Attr:$dim, DefaultValuedAttr<BoolAttr, "false">:$is_linear);
+  let arguments = (ins TA_AnyTensor:$tensor, Optional<Index>:$crd, I32Attr:$dim, DefaultValuedAttr<BoolAttr, "false">:$is_linear);
   let results = (outs Index:$result);
 }
 

--- a/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
+++ b/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
@@ -659,6 +659,11 @@ namespace
       }
 
       Value getPos(IRRewriter& rewriter, Value tensor, uint32_t dim) override {
+        if(llvm::isa<SparseTensorType>(tensor.getType()))
+        {
+          auto loc = rewriter.getUnknownLoc();
+          return rewriter.create<TensorFindPos>(loc, rewriter.getIndexType(), tensor, nullptr, (int32_t)dim, true);
+        }
         return inductionVar;
       }
 
@@ -926,7 +931,7 @@ namespace
         if(semiring == "minxy"){
           zero = INFINITY;
         }
-        return rewriter.create<TensorExtractOp>(loc, element_type, tensor, pos, rewriter.getF64FloatAttr(zero));
+        return rewriter.create<TensorExtractOp>(loc, element_type, tensor, pos, crds, rewriter.getF64FloatAttr(zero));
       }
     }
 
@@ -948,7 +953,7 @@ namespace
         if(semiring == "minxy"){
           zero = INFINITY;
         }
-        return rewriter.create<TensorExtractOp>(loc, rewriter.getF64Type(), tensor, pos, rewriter.getF64FloatAttr(zero));
+        return rewriter.create<TensorExtractOp>(loc, rewriter.getF64Type(), tensor, pos, crds, rewriter.getF64FloatAttr(zero));
       }
     }
 

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -248,7 +248,7 @@ mlir::LogicalResult generalIndexOperationRewrite(
   auto MaskingTypeAttr = mult_op.getMaskTypeAttr();
 
   auto tensor_type = op->getResultTypes()[0];
-  auto itree_op = rewriter.create<IndexTreeOp>(loc, tensor_type);
+  auto itree_op = rewriter.create<IndexTreeOp>(loc, tensor_type, lhs_tensor);
   Region* body = &itree_op.getRegion();
   loc = body->getLoc();
   Block* block = rewriter.createBlock(body);

--- a/lib/Conversion/TensorAlgebraToSCF/SparseTensorConversionPass.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/SparseTensorConversionPass.cpp
@@ -347,6 +347,27 @@ class ConvertSpTensorExtractOp
   }
 };
 
+class ConvertSpTensorGetCrd
+  : public OpConversionPattern<SpTensorGetCrd> {
+  using OpConversionPattern<SpTensorGetCrd>::OpConversionPattern;
+  ConvertSpTensorGetCrd(MLIRContext * context)
+    : OpConversionPattern(context) {}
+
+  LogicalResult matchAndRewrite(SpTensorGetCrd op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
+    auto opAdaptor = llvm::cast<SpTensorGetCrdAdaptor>(adaptor);
+    if(!llvm::isa<SparseTensorType>(opAdaptor.getTensor().getType())){
+      return failure();
+    }
+
+    SparseTensor sp_tensor;
+    if(!unpack_sparse_tensor(opAdaptor.getTensor(), sp_tensor)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<tensor::ExtractOp>(op, op.getType(), sp_tensor.dims[op.getDim().value()].crd, op.getIdx());
+    return success();
+  }
+};
+
 class ConvertSpTensorInsertCrd
     : public OpConversionPattern<SpTensorInsertCrd> {
   using OpConversionPattern<SpTensorInsertCrd>::OpConversionPattern;
@@ -1182,7 +1203,7 @@ void mlir::comet::populateSparseTensorConversionPatterns(MLIRContext *context, R
     });
 
   patterns.add<PrintOpLowering, GetTimeLowering, PrintElapsedTimeLowering>(typeConverter, context);
-  patterns.add<ConvertSpTensorConstructOp, ConvertSpTensorInsertOp, ConvertSpTensorExtractOp, ConvertSpTensorInsertCrd, ConvertSpTensorGetDimSize, ConvertSpTensorGetDimCrd, ConvertSpTensorGetDimPos, ConvertSpTensorGetDimBlockCrd, ConvertSpTensorGetDimBlockPos, ConvertSpTensorGetVals, ConvertSpTensorFindPos>(typeConverter, context);
+  patterns.add<ConvertSpTensorConstructOp, ConvertSpTensorInsertOp, ConvertSpTensorExtractOp, ConvertSpTensorGetCrd, ConvertSpTensorInsertCrd, ConvertSpTensorGetDimSize, ConvertSpTensorGetDimCrd, ConvertSpTensorGetDimPos, ConvertSpTensorGetDimBlockCrd, ConvertSpTensorGetDimBlockPos, ConvertSpTensorGetVals, ConvertSpTensorFindPos>(typeConverter, context);
   patterns.add<ConvertAllocWorkspaceOp, ConvertWorkspaceGetNNZ, ConvertWorkspaceGetCrds, ConvertWorkspaceTensorInsertOp, ConvertWorkspaceTensorExtractOp, ConvertWorkspaceGetDimSize, ConvertWorkspaceClearOp>(typeConverter, context);
 }
 

--- a/lib/Conversion/TensorAlgebraToSCF/SparseTensorConversionPass.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/SparseTensorConversionPass.cpp
@@ -921,8 +921,7 @@ class ConvertWorkspaceTensorExtractOp
 
     auto loc = op.getLoc();
     auto context = op.getContext();
-    Value pos = opAdaptor.getPos();
-    Value crd = rewriter.create<tensor::ExtractOp>(loc, rewriter.getIndexType(), workspace.crds, pos);
+    Value crd = opAdaptor.getCrds()[0];
     Value mark_at_crd = rewriter.create<tensor::ExtractOp>(
       loc,
       rewriter.getI32Type(),

--- a/lib/Dialect/TensorAlgebra/IR/TADialect.cpp
+++ b/lib/Dialect/TensorAlgebra/IR/TADialect.cpp
@@ -306,98 +306,63 @@ llvm::ArrayRef<int64_t> SparseTensorType::getShape() const
   return getDims();
 }
 
-::mlir::Type SparseTensorType::parse(::mlir::AsmParser &odsParser) {
-  if (odsParser.parseLess()) return {};
-  ::mlir::FailureOr<::mlir::Type> _result_element_type;
-  SmallVector<int64_t> result_dims;
-  SmallVector<int32_t> result_formats;
+Type SparseTensorType::parse(AsmParser &odsParser) {
+  Builder odsBuilder(odsParser.getContext());
+  llvm::SMLoc odsLoc = odsParser.getCurrentLocation();
+  (void) odsLoc;
+  FailureOr<Type> _result_element_type;
+  SmallVector<int64_t> _result_dims;
+  FailureOr<SmallVector<int32_t>> _result_format;
 
+  // Parse literal '<'
+  if (odsParser.parseLess()) return {};
 
   // Parse variable 'element_type'
-  _result_element_type = ::mlir::FieldParser<::mlir::Type>::parse(odsParser);
-  if (::mlir::failed(_result_element_type)) {
-    odsParser.emitError(odsParser.getCurrentLocation(), "failed to parse SparseTensor parameter 'element_type' which is to be a `::mlir::Type`");
+  _result_element_type = FieldParser<Type>::parse(odsParser);
+  if (failed(_result_element_type)) {
+    odsParser.emitError(odsParser.getCurrentLocation(), "failed to parse SparseTensor parameter 'element_type' which is to be a `Type`");
     return {};
   }
-
   // Parse literal ','
   if (odsParser.parseComma()) return {};
-  // Parse literal '['
-  if (odsParser.parseLSquare()) return {};
 
   // Parse variable 'dims'
-  do {
-    int64_t dim;
-    if (!odsParser.parseOptionalInteger(dim).has_value()){  // Parse each integer
-      if (odsParser.parseQuestion()){
-        return {};
-      }
-      else {
-        dim = ShapedType::kDynamic;
-      }
-    }
-
-    result_dims.push_back(dim);
-      
-  } while (odsParser.parseOptionalComma().succeeded()); 
-
-    // Parse literal ']'
-  if (odsParser.parseRSquare()) return {};
+  if(odsParser.parseDimensionList(_result_dims, true, false)) {
+    odsParser.emitError(odsParser.getCurrentLocation(), "failed to parse SparseTensor parameter 'dims' which is to be a `ArrayRef<int64_t>`");
+    return {};
+  }
   // Parse literal ','
   if (odsParser.parseComma()) return {};
-  // Parse literal '['
-  if (odsParser.parseLSquare()) return {};
-
 
   // Parse variable 'format'
-  do {
-    int32_t format;
-    if (odsParser.parseInteger(format))  // Parse each integer
-      return {};
-    result_formats.push_back(format);
-  } while (odsParser.parseOptionalComma().succeeded()); 
-
-  // Parse literal ']'
-  if (odsParser.parseRSquare()) return {};
+  _result_format = FieldParser<SmallVector<int32_t>>::parse(odsParser);
+  if (failed(_result_format)) {
+    odsParser.emitError(odsParser.getCurrentLocation(), "failed to parse SparseTensor parameter 'format' which is to be a `ArrayRef<int32_t>`");
+    return {};
+  }
   // Parse literal '>'
   if (odsParser.parseGreater()) return {};
-
-   return SparseTensorType::get(odsParser.getContext(),
-      ::mlir::Type((*_result_element_type)),
-      ::llvm::ArrayRef<int64_t>((result_dims)),
-      ::llvm::ArrayRef<int32_t>((result_formats)));
+  assert(succeeded(_result_element_type));
+  assert(succeeded(_result_format));
+  return SparseTensorType::get(odsParser.getContext(),
+      Type((*_result_element_type)),
+      ArrayRef<int64_t>(_result_dims),
+      ArrayRef<int32_t>((*_result_format)));
 }
 
-
-void SparseTensorType::print(::mlir::AsmPrinter &odsPrinter) const {
-  ::mlir::Builder odsBuilder(getContext());
+void SparseTensorType::print(AsmPrinter &odsPrinter) const {
+  Builder odsBuilder(getContext());
   odsPrinter << "<";
   odsPrinter.printStrippedAttrOrType(getElementType());
   odsPrinter << ",";
-  odsPrinter << ' ' << "[";
-  for(size_t i = 0; i< getDims().size(); i++)
-  {
-    long long v = getDims()[i];
-    if(v == ShapedType::kDynamic)
-    {
-      odsPrinter << "?";
-    }  
-    else 
-    {
-      odsPrinter << v;    
-    }
-    if(i != getDims().size() - 1)
-    {
-      odsPrinter << ", ";
-    }
-  }
-  odsPrinter << "]";
+  odsPrinter << ' ';
+  odsPrinter.printDimensionList(getDims());
   odsPrinter << ",";
-  odsPrinter << ' ' << "[";
+  odsPrinter << ' ';
   odsPrinter.printStrippedAttrOrType(getFormat());
-  odsPrinter << "]";
   odsPrinter << ">";
 }
+
 
 //===----------------------------------------------------------------------===//
 /// TableGen'd type definitions

--- a/lib/Dialect/TensorAlgebra/Transforms/TensorDeclLowering.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/TensorDeclLowering.cpp
@@ -889,11 +889,6 @@ Value insertSparseTensorDeclOp(PatternRewriter & rewriter,
           /// do nothing!
           comet_debug() << " the tensor has use in AllocWorkspaceOp\n";
         }
-        else if (isa<tensorAlgebra::AllocWorkspaceOp>(u1))
-        {
-          /// do nothing!
-          comet_debug() << " the tensor has use in AllocWorkspaceOp\n";
-        }
         else if(isa<func::CallOp>(u1))
         {
           /// do nothing!
@@ -902,6 +897,11 @@ Value insertSparseTensorDeclOp(PatternRewriter & rewriter,
         else if(isa<func::ReturnOp>(u1))
         {
           comet_debug() << " the tensor has use in func::ReturnOp\n";
+        }
+        else if (isa<indexTree::IndexTreeOp>(u1))
+        {
+          /// do nothing!
+          comet_debug() << " the tensor has use in a Index Tree\n";
         }
         else
         {


### PR DESCRIPTION
Another large rework of how we convert from index tree to SCF. This is mostly contained just in how that pass is structured. Previously it was very ad-hoc, each level of the tree was converted individually. This led to problems with tracking users and with determining the loop carried arguments. The new abstractions in that pass (specifically the LoopInfo* data structure) lead to a more understandable conversion, one that should resemble the structure of passes that are written with the MLIR ConversionPatternRewriter. Because operations do not map closely from IndexTree to SCF, it is still impossible, or at least very difficult to use the ConversionPatternRewriter. These changes should also make passes like fusion easier to write with the new index tree dialect.