### PR TITLE
Initial implementation of parallel loops

### DIFF
--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -88,7 +88,7 @@ def IndexTreeIndicesOp : IndexTree_Op<"IndexOp", [Pure]>{
   let description = [{
   }];
 
-  let arguments = (ins IndexTree_NodeType:$parent, Optional<IndexTree_DomainType>:$domain);
+  let arguments = (ins IndexTree_NodeType:$parent, Optional<IndexTree_DomainType>:$domain, DefaultValuedAttr<BoolAttr, "false">:$IsParallel);
 
   let results = (outs IndexTree_IndexNodeType:$output);
 }

--- a/include/comet/Dialect/TensorAlgebra/IR/TATypes.td
+++ b/include/comet/Dialect/TensorAlgebra/IR/TATypes.td
@@ -51,8 +51,7 @@ def SparseTensor : TensorAlgebra_Type<"SparseTensor", "sparse_tensor", [DeclareT
         ArrayRefParameter<"int64_t", "Dimensions of tensor">:$dims,
         ArrayRefParameter<"TensorFormatEnum", "Format">:$format
     );
-
-    // let assemblyFormat = "`<` $element_type `,` $indices_type `,` $dims `,` $format `>`";
+    
     let hasCustomAssemblyFormat = 1;
     // TODO: Implement custom builder from "common" format strings into format strings
 }

--- a/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
+++ b/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
@@ -801,6 +801,10 @@ namespace
       }
 
       Value getPos(IRRewriter& rewriter, Value tensor, uint32_t dim) override {
+        if(llvm::isa<TensorType>(tensor.getType())) {
+          // For dense tensors, positions and crd should be the same.
+          return getCrd(rewriter);
+        }
         return inductionVar;
       }
 

--- a/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
+++ b/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
@@ -52,7 +52,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/Casting.h"
 
 #include <iostream>
 #include <algorithm>
@@ -406,7 +406,64 @@ namespace
     return reduceResult;
   }
 
-  class LoopInfo {
+  struct TensorSubsetInfo {
+    int64_t dim;
+    int64_t tiles;
+    int64_t tile_size;
+  };
+
+
+  class IndexTreeInferOutputSets {
+    SmallDenseMap<IndexTreeIndicesOp, SmallDenseMap<Value, TensorSubsetInfo>> output_sets;
+
+    public:
+    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(IndexTreeInferOutputSets)
+
+    IndexTreeInferOutputSets(Operation* op)
+    {
+      // TODO: Will not work with workspace op or with sparse tensors!
+      // Also will not work with indices that don't align to tensor dims!
+
+      IndexTreeOp tree = llvm::cast<IndexTreeOp>(op);
+      for(Value input : tree.getInputs()) {
+        for(auto user : input.getUsers()) {
+          if(auto lhs = llvm::dyn_cast<IndexTreeLHSOperandOp>(user)) {
+            int64_t dim = 0;
+            for(Value crd : lhs.getCrds()) {
+              if(auto access = crd.getDefiningOp<IndexTreeIndexToTensorOp>()) {
+                auto node = access.getIndex().getDefiningOp<IndexTreeIndicesOp>();
+                TensorSubsetInfo slice = {dim, -1, -1};
+                if(output_sets.contains(node)){
+                  output_sets[node].insert(std::make_pair(input, slice));
+                }
+              }
+              dim += 1; 
+            }
+          }
+        }
+      }
+    }
+
+    SmallDenseMap<Value, TensorSubsetInfo> getOutputSets(IndexTreeIndicesOp op)
+    {
+      if(output_sets.contains(op)){
+        return output_sets[op];
+      }
+
+      // This also will cause errors!!!
+      return SmallDenseMap<Value, TensorSubsetInfo>();
+    }
+
+  };
+
+  class IndexVar {
+    public:
+      virtual Value getCrd(IRRewriter& rewriter) = 0;
+      virtual Value getPos(IRRewriter& rewriter, Value tensor, uint32_t dim) = 0;
+      virtual ~IndexVar(){};
+  };
+
+  class LoopInfo : public IndexVar {
     protected:
       SmallVector<Value> currentInputs;
       ValueRange results;
@@ -456,23 +513,27 @@ namespace
       scf::YieldOp terminator;
 
     public:
-      DenseLoopInfo(ValueRange inputs, ResultRange outputs, Operation* body, IRMapping ir_map, Value i, scf::YieldOp yield): 
-        LoopInfo(inputs, outputs, body, ir_map), inductionVar(i), terminator(yield) {}
+      DenseLoopInfo(ValueRange inputs, 
+                    ResultRange outputs,
+                    Operation* body,
+                    IRMapping ir_map,
+                    Value i, 
+                    scf::YieldOp yield): 
+        LoopInfo(inputs, outputs, body, ir_map), inductionVar(i), terminator(yield){}
 
       static LoopInfo* build(Operation* domain_op, IRRewriter& rewriter, ValueRange inputs)
       {
         auto loc = domain_op->getLoc();
+        Value inductionVar;
         Value lb = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
         Value ub = domain_op->getOperand(0);
         Value step = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(), rewriter.getIndexAttr(1));
         scf::ForOp for_loop = rewriter.create<scf::ForOp>(loc, lb, ub, step, inputs);
-
-        IRMapping map;
         rewriter.setInsertionPointToStart(for_loop.getBody());
-        auto yield_op = rewriter.create<scf::YieldOp>(loc, for_loop.getRegionIterArgs());
+        scf::YieldOp terminator = rewriter.create<scf::YieldOp>(loc, for_loop.getRegionIterArgs());
         rewriter.setInsertionPointAfter(for_loop);
-
-        return new DenseLoopInfo(ValueRange(for_loop.getRegionIterArgs()), for_loop.getResults(), yield_op, map, for_loop.getInductionVar(), yield_op);
+        IRMapping map;
+        return new DenseLoopInfo(for_loop.getRegionIterArgs(), for_loop->getResults(), terminator, map, for_loop.getInductionVar(), terminator);
       }
 
       Value getCrd(IRRewriter& rewriter) override {return inductionVar;}
@@ -493,7 +554,140 @@ namespace
 
       void updateOutput(IRRewriter& rewriter, uint32_t idx, Value newOutput) override {
         currentInputs[idx] = newOutput;
-        rewriter.updateRootInPlace(terminator, [&](){terminator.setOperand(idx, newOutput);});
+       rewriter.updateRootInPlace(terminator, [&](){terminator.setOperand(idx, newOutput);});
+      }
+  };
+
+  class DenseParallelLoopInfo : public LoopInfo {
+    private:
+      Value inductionVar;
+      SmallVector<Operation*> terminator_ops;
+      SmallDenseMap<Value, TensorSubsetInfo> output_sets;
+
+    public:
+      DenseParallelLoopInfo(ValueRange inputs, 
+                            ResultRange outputs,
+                            Operation* body,
+                            IRMapping ir_map,
+                            Value i,
+                            SmallVector<Operation*>& terminator_ops,
+                            SmallDenseMap<Value, TensorSubsetInfo> output_sets): 
+        LoopInfo(inputs, outputs, body, ir_map), inductionVar(i), terminator_ops(terminator_ops), output_sets(output_sets) {}
+
+      static LoopInfo* build(Operation* domain_op, IRRewriter& rewriter, ValueRange inputs, SmallDenseMap<Value, TensorSubsetInfo> output_sets)
+      {
+        auto loc = domain_op->getLoc();
+        Value ub = domain_op->getOperand(0);
+        scf::ForallOp for_loop = rewriter.create<scf::ForallOp>(
+          loc,
+          ArrayRef<OpFoldResult>(ub),
+          inputs,
+          std::nullopt,
+          nullptr);
+        Value inductionVar = for_loop.getInductionVar(0);
+        rewriter.setInsertionPointToStart(for_loop.getBody());
+
+        SmallVector<Value> input_slices;        
+        for(auto input : inputs)
+        {
+          auto& os = output_sets.at(input);
+          RankedTensorType tt = llvm::cast<RankedTensorType>(input.getType());
+          int64_t nDims = tt.getRank();
+          SmallVector<Value> sizes;
+          SmallVector<int64_t> shape;
+          for(int i = 0; i < nDims; i++)
+          {
+            if(i !=  os.dim) {
+              Value idx = rewriter.create<index::ConstantOp>(loc, rewriter.getIndexType(), rewriter.getIndexAttr(i));
+              sizes.push_back(rewriter.create<tensor::DimOp>(loc, rewriter.getIndexType(), input, idx));
+              shape.push_back(tt.getDimSize(i));
+            } else {
+              sizes.push_back(rewriter.create<index::ConstantOp>(loc, rewriter.getIndexType(), rewriter.getIndexAttr(1)));
+            }
+          }
+
+          auto slice = rewriter.create<tensor::ExtractSliceOp>(
+            loc,
+            RankedTensorType::get(shape, tt.getElementType()),
+            input,
+            ValueRange(),
+            sizes,
+            ValueRange(),
+            rewriter.getDenseI64ArrayAttr(SmallVector<int64_t>(nDims, 0)),
+            rewriter.getDenseI64ArrayAttr(SmallVector<int64_t>(nDims, ShapedType::kDynamic)),
+            rewriter.getDenseI64ArrayAttr(SmallVector<int64_t>(nDims, 1))
+          );
+          input_slices.push_back(slice->getResult(0));
+        }
+
+        SmallVector<Operation*> terminator_ops;
+        auto par_op = rewriter.create<scf::InParallelOp>(loc);
+        auto slice = input_slices.begin();
+        for(auto input : inputs) {
+          rewriter.setInsertionPoint(par_op);
+          auto& os = output_sets.at(input);
+          int64_t nDims = llvm::cast<RankedTensorType>(input.getType()).getRank();
+          SmallVector<Value> sizes;
+          for(int i = 0; i < nDims; i++)
+          {
+            if(i !=  os.dim) {
+              Value idx = rewriter.create<index::ConstantOp>(loc, rewriter.getIndexType(), rewriter.getIndexAttr(i));
+              sizes.push_back(rewriter.create<tensor::DimOp>(loc, rewriter.getIndexType(), input, idx));
+            } else {
+              sizes.push_back(rewriter.create<index::ConstantOp>(loc, rewriter.getIndexType(), rewriter.getIndexAttr(1)));
+            }
+          }
+
+          rewriter.setInsertionPointToEnd(par_op.getBody());
+          Operation* insert = rewriter.create<tensor::ParallelInsertSliceOp>(
+            loc, 
+            *slice,
+            input,
+            ValueRange(),
+            sizes,
+            ValueRange(),
+            rewriter.getDenseI64ArrayAttr(SmallVector<int64_t>(nDims, 0)),
+            rewriter.getDenseI64ArrayAttr(SmallVector<int64_t>(nDims, ShapedType::kDynamic)),
+            rewriter.getDenseI64ArrayAttr(SmallVector<int64_t>(nDims, 1))
+          );
+          terminator_ops.push_back(insert);
+          slice++;
+        }
+        rewriter.setInsertionPointAfter(for_loop);
+        
+        IRMapping map;
+        return new DenseParallelLoopInfo(input_slices, for_loop.getResults(), par_op, map, inductionVar, terminator_ops, output_sets);
+      }
+
+      Value getCrd(IRRewriter& rewriter) override {return inductionVar;}
+
+      Value getPos(IRRewriter& rewriter, Value tensor, uint32_t dim) override {
+        if(dyn_cast<TensorType>(tensor.getType())){
+          // TODO: Fix me. Right now, getCrd on the output tensor is just one becuase 
+          // we have already extracted the slice that we want. This will only work 
+          // in very limited scenarios
+          if(output_sets.contains(tensor)){
+            Value one = rewriter.create<index::ConstantOp>(tensor.getLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(1));
+            return one;
+          } else {
+            return inductionVar;
+          }
+          
+        } else if(SparseTensorType tt = dyn_cast<SparseTensorType>(tensor.getType())){
+          if((TensorFormatEnum)(tt.getFormat()[2 * dim]) == TensorFormatEnum::D) {
+            return inductionVar;
+          }
+          assert(false && "Invalid type passed to DenseLoopInfo getPos");
+          return nullptr;
+        }
+        assert(false && "Invalid type passed to DenseLoopInfo getPos");
+        return nullptr;
+      }
+
+      void updateOutput(IRRewriter& rewriter, uint32_t idx, Value newOutput) override {
+        currentInputs[idx] = newOutput;
+        Operation* terminator = terminator_ops[idx];
+        rewriter.updateRootInPlace(terminator, [&](){terminator->setOperand(0, newOutput);});
       }
   };
 
@@ -1003,7 +1197,7 @@ namespace
       Value output_tensor;
       if(llvm::isa<mlir::TensorType>(old_tensor.getType()))
       {
-        output_tensor = rewriter.create<tensor::InsertOp>(loc, old_tensor.getType(), reduce_result, old_tensor, lhs.getCrds());
+        output_tensor = rewriter.create<tensor::InsertOp>(loc, old_tensor.getType(), reduce_result, old_tensor, lhs.getPos());
       } else {
         output_tensor = rewriter.create<tensorAlgebra::TensorInsertOp>(loc, old_tensor.getType(), old_tensor, lhs.getPos(), lhs.getCrds(), reduce_result);
       }
@@ -1098,6 +1292,7 @@ namespace
 
     mlir::LogicalResult convertIndexNode(IndexTreeIndicesOp index_node_op, IRRewriter &rewriter)
     {
+      IndexTreeOp tree = index_node_op->getParentOfType<IndexTreeOp>();
       Operation* domain_op = index_node_op.getDomain().getDefiningOp();
       Value index_node = index_node_op->getResult(0);
       LoopInfo* parent_info = nodeMap.find(index_node_op.getParent())->getSecond();
@@ -1105,6 +1300,17 @@ namespace
 
       LoopInfo* loop_info = llvm::TypeSwitch<Operation*, LoopInfo*>(domain_op) 
         .Case<IndexTreeDenseDomainOp>([&](IndexTreeDenseDomainOp op) {
+          if(index_node_op.getIsParallel()){
+            ValueRange inputs = parent_info->getInputs();
+            auto output_analysis = Pass::getChildAnalysis<IndexTreeInferOutputSets>(index_node_op->getParentOp());
+            auto output_sets = output_analysis.getOutputSets(index_node_op);
+            uint32_t i = 0;
+            for(Value v: inputs){
+              output_sets.insert(std::make_pair(v, output_sets[tree.getOperand(i)]));
+              i++;
+            }
+            return DenseParallelLoopInfo::build(op, rewriter, parent_info->getInputs(), output_sets);
+          }
           return DenseLoopInfo::build(op, rewriter, parent_info->getInputs());
         })
         .Case<IndexTreeSparseDomainOp>([&](IndexTreeSparseDomainOp op) {

--- a/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
+++ b/lib/Conversion/IndexTreeToSCF/IndexTreeToSCF.cpp
@@ -433,9 +433,7 @@ namespace
               if(auto access = crd.getDefiningOp<IndexTreeIndexToTensorOp>()) {
                 auto node = access.getIndex().getDefiningOp<IndexTreeIndicesOp>();
                 TensorSubsetInfo slice = {dim, -1, -1};
-                if(output_sets.contains(node)){
-                  output_sets[node].insert(std::make_pair(input, slice));
-                }
+                output_sets[node].insert(std::make_pair(input, slice));
               }
               dim += 1; 
             }
@@ -1159,7 +1157,7 @@ namespace
 
       TensorType tensor_type;
       if((tensor_type = llvm::dyn_cast<mlir::TensorType>(tensor.getType()))){
-        return rewriter.create<tensor::ExtractOp>(loc, tensor_type.getElementType(), tensor, positions);
+        return rewriter.create<tensor::ExtractOp>(loc, tensor_type.getElementType(), tensor, crds);
       } else {
         // LHS may not be constant (i.e. if we are inserting into a tensor that we need to resize), 
         // so cannot directly lower like we can the RHS

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -265,6 +265,13 @@ mlir::LogicalResult generalIndexOperationRewrite(
   indexTree::IndexNodeType index_node_type = indexTree::IndexNodeType::get(context); 
   std::vector<Value> index_nodes;
   bool is_parallel = true; // Outer-most, non-reduction dimensions are parallel
+
+  // TODO: For now, we do not support outputting sparse tensors from a parallel loop.
+  if(llvm::isa<SparseTensorType>(tensor_type))
+  {
+    is_parallel = false;
+  }
+  
   for (unsigned i = 0; i < lhsMap.getNumDims(); i++)
   {
     if(!lhsMap.isFunctionOfDim(i)){

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -261,12 +261,16 @@ mlir::LogicalResult generalIndexOperationRewrite(
   Value parent = rewriter.create<indexTree::IndexTreeRootOp>(loc, tree_type);
 
   //Construct each index variable
-  auto lhsMap = indexing_maps[2].template cast<AffineMapAttr>().getValue();
+  auto lhsMap = cast<AffineMapAttr>(indexing_maps[2]).getValue();
   indexTree::IndexNodeType index_node_type = indexTree::IndexNodeType::get(context); 
   std::vector<Value> index_nodes;
+  bool is_parallel = true; // Outer-most, non-reduction dimensions are parallel
   for (unsigned i = 0; i < lhsMap.getNumDims(); i++)
   {
-    parent = rewriter.create<indexTree::IndexTreeIndicesOp>(loc, index_node_type, parent);
+    if(!lhsMap.isFunctionOfDim(i)){
+      is_parallel = false;
+    }
+    parent = rewriter.create<indexTree::IndexTreeIndicesOp>(loc, index_node_type, parent, nullptr, is_parallel);
     index_nodes.push_back(parent);
   }
 

--- a/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
+++ b/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
@@ -150,11 +150,11 @@ struct ConcretizeTensorDomain :  public OpRewritePattern<IndexTreeTensorDomainOp
           }
         }
         rewriter.restoreInsertionPoint(prev);
-
+        Value max = rewriter.create<tensorAlgebra::SpTensorGetDimSize>(loc, rewriter.getIndexType(), tensor, rewriter.getI32IntegerAttr(dim));
         new_domain = rewriter.create<IndexTreeSparseDomainOp>(
           loc, domain_type, tensor, domain_op.getDimAttr(), 
           TensorFormatEnumAttr::get(context, format), 
-          pos, crd, pos_size, crd_size, dim_size, parent);
+          pos, crd, pos_size, crd_size, dim_size, parent, rewriter.getBoolAttr(false), max);
       }
     } 
     else if(llvm::isa<tensorAlgebra::WorkspaceType>(tensor.getType())) {

--- a/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
+++ b/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
@@ -154,7 +154,7 @@ struct ConcretizeTensorDomain :  public OpRewritePattern<IndexTreeTensorDomainOp
         new_domain = rewriter.create<IndexTreeSparseDomainOp>(
           loc, domain_type, tensor, domain_op.getDimAttr(), 
           TensorFormatEnumAttr::get(context, format), 
-          pos, crd, pos_size, crd_size, dim_size, parent, rewriter.getBoolAttr(false), max);
+          pos, crd, pos_size, crd_size, dim_size, parent);
       }
     } 
     else if(llvm::isa<tensorAlgebra::WorkspaceType>(tensor.getType())) {

--- a/lib/Dialect/IndexTree/Transforms/IterationDomainInference.cpp
+++ b/lib/Dialect/IndexTree/Transforms/IterationDomainInference.cpp
@@ -141,7 +141,7 @@ struct InferIndexDomain : public OpRewritePattern<IndexTreeIndicesOp> {
 
     indexTree::IndexNodeType index_node_type = indexTree::IndexNodeType::get(context); 
     builder.replaceOpWithNewOp<indexTree::IndexTreeIndicesOp>(
-                          op, index_node_type, op.getParent(), final_domain);
+                          op, index_node_type, op.getParent(), final_domain, op.getIsParallelAttr());
     return success();
   }
 };

--- a/lib/Dialect/TensorAlgebra/IR/TADialect.cpp
+++ b/lib/Dialect/TensorAlgebra/IR/TADialect.cpp
@@ -378,7 +378,6 @@ void SparseTensorType::print(::mlir::AsmPrinter &odsPrinter) const {
   odsPrinter << ">";
 }
 
-
 //===----------------------------------------------------------------------===//
 /// TableGen'd type definitions
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Implementation of parallel loops using SCF forall operation. Currently the parallel loops are limited to (1) dense outputs, (2) non-reduction dimensions and (3) dense iteration spaces. As we continue, we will try to relax these constraints.