### PR TITLE
Indextree fusion fix domain inference

### DIFF
--- a/include/comet/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.h
+++ b/include/comet/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.h
@@ -1,0 +1,26 @@
+#ifndef COMET_DIALECT_INDEXTREE_ANALYSIS_H
+#define COMET_DIALECT_INDEXTREE_ANALYSIS_H
+
+#include "mlir/IR/Value.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/ADT/SmallSet.h"
+
+#include "comet/Dialect/IndexTree/IR/IndexTreeDialect.h"
+
+namespace mlir {
+    namespace indexTree {
+        struct CopiedDomainAnalysis {
+            public:
+            CopiedDomainAnalysis(Operation* op);
+            bool isCopiedDomain(Value tensor, unsigned dim);
+
+            private:
+            llvm::SmallDenseSet<std::pair<Value, uint32_t>> copiedDomains;
+            void analyzeDomains(IndexTreeComputeOp compute_op);
+        };
+        
+    }
+}
+
+#endif // COMET_DIALECT_INDEXTREE_ANALYSIS_H

--- a/include/comet/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.h
+++ b/include/comet/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.h
@@ -14,9 +14,11 @@ namespace mlir {
             public:
             CopiedDomainAnalysis(Operation* op);
             bool isCopiedDomain(Value tensor, unsigned dim);
+            bool isReductionVar(IndexTreeComputeOp op, Value index_var);
 
             private:
             llvm::SmallDenseSet<std::pair<Value, uint32_t>> copiedDomains;
+            llvm::SmallDenseSet<std::pair<IndexTreeComputeOp, Value>> reductionVars;
             void analyzeDomains(IndexTreeComputeOp compute_op);
         };
         

--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -53,11 +53,12 @@ class IndexTree_Op<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 def IndexTreeOp : IndexTree_Op<"itree", 
-    [SingleBlockImplicitTerminator<"indexTree::YieldOp">]> {
+    [SingleBlockImplicitTerminator<"indexTree::YieldOp">, AttrSizedOperandSegments]> {
+      
   let summary = "Create a scope for index tree iteration";
   let description = [{}];
 
-  let arguments = (ins Variadic<AnyType>:$inputs);
+  let arguments = (ins Variadic<AnyType>:$inputs, Variadic<AnyType>:$intermediates);
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>:$region);
 }

--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -203,7 +203,7 @@ def IndexTreeDenseDomainOp : IndexTree_Op<"DenseDomainOp",
   let description = [{
   }];
 
-  let arguments = (ins AnyTypeOf<[UI32,Index]>:$dim_size, Variadic<TA_AnyTensor>:$tensors, I32ArrayAttr:$dims);
+  let arguments = (ins AnyTypeOf<[UI32,Index,I32]>:$dim_size, Variadic<TA_AnyTensor>:$tensors, I32ArrayAttr:$dims);
 
   let results = (outs IndexTree_DomainType:$domain);
 }
@@ -228,7 +228,7 @@ def IndexTreeDomainUnionOp : IndexTree_Op<"DomainUnionOp",
   let description = [{
   }];
 
-  let arguments = (ins Variadic<IndexTree_DomainType>:$domains, Optional<Index>:$dim_size);
+  let arguments = (ins Variadic<IndexTree_DomainType>:$domains, Optional<AnyTypeOf<[I32,Index]>>:$dim_size);
   let results = (outs IndexTree_DomainType:$domain);
 }
 

--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -76,6 +76,23 @@ def YieldOp : IndexTree_Op<"yield", [Pure, ReturnLike, Terminator,
       [{  attr-dict ($results^ `:` type($results))? }];
 }
 
+def IndexTreeNodeInterface : OpInterface<"IndexTreeNode"> {
+  let description = [{
+    Describes any operation which is attached to specific point in the tree.
+  }];
+  let cppNamespace = "::mlir::indexTree";
+
+  let methods = [
+    InterfaceMethod<
+      [{Method to get the dimension size of a concrete dimension.}],
+      "mlir::Value", "getParentNode", (ins), /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return $_op.getParent();
+      }]
+    >,
+  ];
+}
+
 def IndexTreeRootOp : IndexTree_Op<"RootOp", [
     HasParent<"IndexTreeOp">, Pure]> {
   let summary = "Create the base of the iteration tree";
@@ -84,7 +101,7 @@ def IndexTreeRootOp : IndexTree_Op<"RootOp", [
   let results = (outs IndexTree_TreeType:$output);
 }
 
-def IndexTreeIndicesOp : IndexTree_Op<"IndexOp", [Pure]>{
+def IndexTreeIndicesOp : IndexTree_Op<"IndexOp", [Pure, IndexTreeNodeInterface]>{
   let summary = "Create an index variable bound to a specific computation.";
   let description = [{
   }];
@@ -93,7 +110,7 @@ def IndexTreeIndicesOp : IndexTree_Op<"IndexOp", [Pure]>{
 
   let results = (outs IndexTree_IndexNodeType:$output);
 }
-def IndexTreeLHSOperandOp : IndexTree_Op<"LHSOperandOp", [Pure, SameVariadicOperandSize]>{
+def IndexTreeLHSOperandOp : IndexTree_Op<"LHSOperandOp", [Pure, SameVariadicOperandSize, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{}];
 
@@ -103,9 +120,20 @@ def IndexTreeLHSOperandOp : IndexTree_Op<"LHSOperandOp", [Pure, SameVariadicOper
     Variadic<Index>:$pos,
     Variadic<Index>:$crds);
   let results = (outs IndexTree_OperandType:$result);
+
+  let extraClassDeclaration = [{
+    Value getParentNode() { 
+      for(Operation* user : getOperation()->getUsers()) {
+        if(auto compute_op = llvm::dyn_cast<IndexTreeComputeOp>(user)) {
+          return compute_op.getParentNode();
+        }
+      }
+      return nullptr;
+    }
+  }];
 }
 
-def IndexTreeOperandOp : IndexTree_Op<"OperandOp", [Pure, SameVariadicOperandSize]>{
+def IndexTreeOperandOp : IndexTree_Op<"OperandOp", [Pure, SameVariadicOperandSize, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{}];
 
@@ -115,9 +143,20 @@ def IndexTreeOperandOp : IndexTree_Op<"OperandOp", [Pure, SameVariadicOperandSiz
     Variadic<Index>:$pos,
     Variadic<Index>:$crds);
   let results = (outs IndexTree_OperandType:$result);
+
+  let extraClassDeclaration = [{
+    Value getParentNode() { 
+      for(Operation* user : getOperation()->getUsers()) {
+        if(auto compute_op = llvm::dyn_cast<IndexTreeComputeOp>(user)) {
+          return compute_op.getParentNode();
+        }
+      }
+      return nullptr;
+    }
+  }];
 }
 
-def IndexTreeComputeOp : IndexTree_Op<"ComputeOp", [Pure, AttrSizedOperandSegments]>{
+def IndexTreeComputeOp : IndexTree_Op<"ComputeOp", [Pure, AttrSizedOperandSegments, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{
   }];
@@ -141,7 +180,22 @@ def IndexTreeComputeOp : IndexTree_Op<"ComputeOp", [Pure, AttrSizedOperandSegmen
   //let hasVerifier = 1;
 }
 
-def IndexTreeTensorDomainOp : IndexTree_Op<"DomainOp", [Pure]>{
+class IndexTreeDomain_Op<string mnemonic, list<Trait> traits = []> :
+    IndexTree_Op<mnemonic, traits>{
+
+  let extraClassDeclaration = [{
+    Value getParentNode() { 
+      for(Operation* user : getOperation()->getUsers()) {
+        if(auto index_node = llvm::dyn_cast<IndexTreeNode>(user)) {
+          return index_node.getParentNode();
+        }
+      }
+      return nullptr;
+    }
+  }];
+}
+
+def IndexTreeTensorDomainOp : IndexTreeDomain_Op<"DomainOp", [Pure, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{
   }];
@@ -151,7 +205,7 @@ def IndexTreeTensorDomainOp : IndexTree_Op<"DomainOp", [Pure]>{
   let results = (outs IndexTree_DomainType:$domain);
 }
 
-def IndexTreeEmptyDomainOp : IndexTree_Op<"EmptyDomain", [Pure]>{
+def IndexTreeEmptyDomainOp : IndexTreeDomain_Op<"EmptyDomain", [Pure, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{
   }];
@@ -177,8 +231,8 @@ def ConcreteDomainInterface : OpInterface<"ConcreteDomain"> {
   ];
 }
 
-def IndexTreeSparseDomainOp : IndexTree_Op<"SparseDomainOp", 
-    [Pure, ConcreteDomainInterface]>{
+def IndexTreeSparseDomainOp : IndexTreeDomain_Op<"SparseDomainOp", 
+    [Pure, ConcreteDomainInterface, IndexTreeNodeInterface]>{
 
   let summary = "";
   let description = [{
@@ -198,8 +252,8 @@ def IndexTreeSparseDomainOp : IndexTree_Op<"SparseDomainOp",
   let results = (outs IndexTree_DomainType:$domain);
 }
 
-def IndexTreeDenseDomainOp : IndexTree_Op<"DenseDomainOp", 
-    [Pure, SameVariadicOperandSize, ConcreteDomainInterface]>{
+def IndexTreeDenseDomainOp : IndexTreeDomain_Op<"DenseDomainOp", 
+    [Pure, SameVariadicOperandSize, ConcreteDomainInterface, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{
   }];
@@ -209,8 +263,8 @@ def IndexTreeDenseDomainOp : IndexTree_Op<"DenseDomainOp",
   let results = (outs IndexTree_DomainType:$domain);
 }
 
-def IndexTreeWorkspaceDomainOp : IndexTree_Op<"WorkspaceDomainOp", 
-    [Pure, ConcreteDomainInterface]>{
+def IndexTreeWorkspaceDomainOp : IndexTreeDomain_Op<"WorkspaceDomainOp", 
+    [Pure, ConcreteDomainInterface, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{}];
 
@@ -223,8 +277,8 @@ def IndexTreeWorkspaceDomainOp : IndexTree_Op<"WorkspaceDomainOp",
   let results = (outs IndexTree_DomainType:$domain);
 }
 
-def IndexTreeDomainUnionOp : IndexTree_Op<"DomainUnionOp", 
-    [Pure, UnknownDomain, ConcreteDomainInterface, AttrSizedOperandSegments]>{
+def IndexTreeDomainUnionOp : IndexTreeDomain_Op<"DomainUnionOp", 
+    [Pure, UnknownDomain, ConcreteDomainInterface, AttrSizedOperandSegments, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{
   }];
@@ -233,8 +287,8 @@ def IndexTreeDomainUnionOp : IndexTree_Op<"DomainUnionOp",
   let results = (outs IndexTree_DomainType:$domain);
 }
 
-def IndexTreeDomainIntersectionOp : IndexTree_Op<"DomainIntersectionOp",
-    [Pure, UnknownDomain, ConcreteDomainInterface, AttrSizedOperandSegments]>{
+def IndexTreeDomainIntersectionOp : IndexTreeDomain_Op<"DomainIntersectionOp",
+    [Pure, UnknownDomain, ConcreteDomainInterface, AttrSizedOperandSegments, IndexTreeNodeInterface]>{
   let summary = "";
   let description = [{
   }];

--- a/include/comet/Dialect/IndexTree/Patterns.h
+++ b/include/comet/Dialect/IndexTree/Patterns.h
@@ -26,11 +26,13 @@
 
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "comet/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.h"
+
 namespace mlir
 {
     namespace indexTree
     {
-        void populateDomainInferencePatterns(MLIRContext *context, RewritePatternSet &patterns);
+        void populateDomainInferencePatterns(MLIRContext *context, RewritePatternSet &patterns, CopiedDomainAnalysis &copiedDomains);
         void populateDomainConcretizationPatterns(MLIRContext *context, RewritePatternSet &patterns);
         void populateIndexTreeTypeConversionPatterns(MLIRContext *context, RewritePatternSet &patterns, TypeConverter &typeConverter, ConversionTarget& target);
         void populateIndexTreeInliningPatterns(MLIRContext *context, RewritePatternSet &patterns);

--- a/lib/Conversion/IndexTreeToSCF/IndexTreeConversion.cpp
+++ b/lib/Conversion/IndexTreeToSCF/IndexTreeConversion.cpp
@@ -106,7 +106,7 @@ class ConvertIndexTreeTypes : public OpConversionPattern<indexTree::IndexTreeOp>
     }
 
     // Calls the actual converter implementation to convert the operation.
-    auto newOp = rewriter.create<indexTree::IndexTreeOp>(op.getLoc(), dstTypes, unpacked);
+    auto newOp = rewriter.create<indexTree::IndexTreeOp>(op.getLoc(), dstTypes, unpacked, op->getAttrs());
     rewriter.inlineRegionBefore(op.getRegion(), newOp.getRegion(), newOp.getRegion().end());
     if (failed(rewriter.convertRegionTypes(&newOp.getRegion(), *typeConverter)))
       return failure();

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -256,7 +256,7 @@ mlir::LogicalResult generalIndexOperationRewrite(
   auto MaskingTypeAttr = mult_op.getMaskTypeAttr();
 
   auto tensor_type = op->getResultTypes()[0];
-  auto itree_op = rewriter.create<IndexTreeOp>(loc, tensor_type, lhs_tensor);
+  auto itree_op = rewriter.create<IndexTreeOp>(loc, tensor_type, ValueRange(lhs_tensor), ValueRange());
   Region* body = &itree_op.getRegion();
   loc = body->getLoc();
   Block* block = rewriter.createBlock(body, {}, TypeRange(lhs_tensor.getType()), {lhs_tensor.getLoc()});

--- a/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
+++ b/lib/Conversion/TensorAlgebraToIndexTree/TensorAlgebraToIndexTree.cpp
@@ -28,7 +28,6 @@
 #include "comet/Dialect/IndexTree/Transforms/Tensor.h"
 #include "comet/Dialect/TensorAlgebra/IR/TADialect.h"
 #include "comet/Dialect/IndexTree/Transforms/UnitExpression.h"
-#include "comet/Dialect/IndexTree/IR/IndexTree.h"
 #include "comet/Dialect/IndexTree/IR/IndexTreeDialect.h"
 #include "comet/Dialect/IndexTree/Passes.h"
 #include "comet/Dialect/Utils/Utils.h"

--- a/lib/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.cpp
+++ b/lib/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.cpp
@@ -35,6 +35,7 @@ for(Value rhs : compute_op.getRhs()){
     auto index_to_tensor = positions[dim].getDefiningOp<IndexTreeIndexToTensorOp>();
     Value index = index_to_tensor.getIndex();
     if(!output_vars.contains(index)) { // It's a reduction variable!
+        reductionVars.insert(std::make_pair(compute_op, index));
         candidates.erase(index);
         break;
     }
@@ -57,4 +58,9 @@ for(auto it = candidates.begin(); it != candidates.end(); it++) {
 bool CopiedDomainAnalysis::isCopiedDomain(Value tensor, unsigned dim)
 {
     return copiedDomains.contains(std::make_pair(tensor, dim));
+}
+
+bool CopiedDomainAnalysis::isReductionVar(IndexTreeComputeOp op, Value index_var)
+{
+    return reductionVars.contains(std::make_pair(op, index_var));
 }

--- a/lib/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.cpp
+++ b/lib/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.cpp
@@ -1,0 +1,60 @@
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/DenseMap.h"
+
+#include "comet/Dialect/IndexTree/IR/IndexTreeDialect.h"
+#include "comet/Dialect/IndexTree/Analysis/CopiedDomainAnalysis.h"
+
+using namespace mlir;
+using namespace mlir::indexTree;
+
+CopiedDomainAnalysis::CopiedDomainAnalysis(Operation* op)
+{
+    op->walk([&](IndexTreeOp tree_op) {
+        tree_op.getBody()->walk([&](IndexTreeComputeOp compute_op) {
+            analyzeDomains(compute_op);
+        });
+    });
+}
+
+void CopiedDomainAnalysis::analyzeDomains(IndexTreeComputeOp compute_op)
+{
+llvm::SmallDenseSet<Value> output_vars;
+llvm::SmallDenseMap<Value, uint32_t> candidates;
+IndexTreeLHSOperandOp lhs = compute_op.getLhs().getDefiningOp<IndexTreeLHSOperandOp>();
+Value tensor = compute_op.getResult();
+for(Value pos : lhs.getPos()){
+    auto index_to_tensor = pos.getDefiningOp<IndexTreeIndexToTensorOp>();
+    output_vars.insert(index_to_tensor.getIndex());
+    candidates.insert(std::make_pair(index_to_tensor.getIndex(), index_to_tensor.getDim()));
+}
+
+for(Value rhs : compute_op.getRhs()){
+    auto positions = rhs.getDefiningOp<IndexTreeOperandOp>().getPos();
+    uint32_t dim = 0;
+    for(; dim < positions.size(); dim += 1){
+    auto index_to_tensor = positions[dim].getDefiningOp<IndexTreeIndexToTensorOp>();
+    Value index = index_to_tensor.getIndex();
+    if(!output_vars.contains(index)) { // It's a reduction variable!
+        candidates.erase(index);
+        break;
+    }
+    }
+
+    // Erase everything that comes after a reduction variable
+    for(dim += 1; dim < positions.size(); dim += 1){
+    auto index_to_tensor = positions[dim].getDefiningOp<IndexTreeIndexToTensorOp>();
+    Value index = index_to_tensor.getIndex();
+    candidates.erase(index);
+    }
+}
+
+for(auto it = candidates.begin(); it != candidates.end(); it++) {
+    uint32_t dim = it->getSecond();
+    copiedDomains.insert(std::make_pair(tensor, dim));
+}
+}
+
+bool CopiedDomainAnalysis::isCopiedDomain(Value tensor, unsigned dim)
+{
+    return copiedDomains.contains(std::make_pair(tensor, dim));
+}

--- a/lib/Dialect/IndexTree/CMakeLists.txt
+++ b/lib/Dialect/IndexTree/CMakeLists.txt
@@ -8,6 +8,8 @@ add_mlir_dialect_library(COMETIndexTreeDialect
   Transforms/WorkspaceTransforms.cpp
   Transforms/KernelFusion.cpp
 
+  Analysis/CopiedDomainAnalysis.cpp
+
   ADDITIONAL_HEADER_DIRS
   ${COMET_MAIN_INCLUDE_DIR}/comet/Dialect/IndexTree
 

--- a/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
+++ b/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
@@ -207,8 +207,6 @@ struct ConcretizeTensorDomain :  public OpRewritePattern<IndexTreeTensorDomainOp
       );
     } else {
       //Domain is dense
-      //TODO (alokvk2): Figure out if we need to take the root index variable or the allocation
-      //Right now I don't know how to get back to the root index variable.
       auto tensor_type = llvm::cast<TensorType>(tensor.getType());
       auto max = tensor_type.getShape()[dim];
       Value max_val;

--- a/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
+++ b/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
@@ -282,9 +282,10 @@ struct SimplifyIntersectionOp : public OpRewritePattern<IndexTreeDomainIntersect
         // TODO: Do we need this to check if the domains are compatible?
         for(Value new_max : maximums){
           if(arith::ConstantOp c = new_max.getDefiningOp<arith::ConstantOp>()){
-            if(llvm::cast<IntegerAttr>(c.getValue()).getValue() == -1){
+            if(llvm::cast<IntegerAttr>(c.getValue()).getValue().isNegative()){
               continue;
             }
+            continue;
           }
           max = new_max;
           break;

--- a/lib/Dialect/IndexTree/Transforms/SymbolicCompute.cpp
+++ b/lib/Dialect/IndexTree/Transforms/SymbolicCompute.cpp
@@ -255,7 +255,7 @@ struct CreateSymbolicTree :  public OpRewritePattern<IndexTreeSparseTensorOp> {
       dim += 1;
     }
 
-    auto itree_op = rewriter.create<IndexTreeOp>(loc, llvm::SmallVector<Type>(symbolic_domains.size(), domain_type), input_domains);
+    auto itree_op = rewriter.create<IndexTreeOp>(loc, llvm::SmallVector<Type>(symbolic_domains.size(), domain_type), input_domains, ValueRange());
     Region* body = &itree_op.getRegion();
     loc = body->getLoc();
     Block* block = rewriter.createBlock(body, {}, llvm::SmallVector<Type>(symbolic_domains.size(), domain_type), llvm::SmallVector<Location>(symbolic_domains.size(), loc));

--- a/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
+++ b/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
@@ -255,12 +255,12 @@ struct TransformSparseOutput : public OpRewritePattern<IndexTreeComputeOp> {
 
 
     // Update the index tree op
-    SmallVector<Value> tree_args(tree_op->getOperands());
+    SmallVector<Value> tree_temps(tree_op.getIntermediates());
     SmallVector<Type> tree_types(tree_op->getResultTypes());
-    tree_args.push_back(workspace);
+    tree_temps.push_back(workspace);
     tree_types.push_back(workspace_type);
     rewriter.setInsertionPoint(tree_op);
-    auto newOp = rewriter.create<IndexTreeOp>(loc, tree_types, tree_args);
+    auto newOp = rewriter.create<IndexTreeOp>(loc, tree_types, tree_op.getInputs(), tree_temps);
     rewriter.inlineRegionBefore(tree_op.getRegion(), newOp.getRegion(), newOp.getRegion().end());
     indexTree::YieldOp yield = cast<indexTree::YieldOp>(newOp.getRegion().getBlocks().front().getTerminator());
     rewriter.updateRootInPlace(yield, [&]() {

--- a/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
+++ b/lib/Dialect/IndexTree/Transforms/WorkspaceTransforms.cpp
@@ -369,7 +369,8 @@ void IndexTreeWorkspaceTransformationsPass::runOnOperation()
   mlir::RewritePatternSet workspace_transformation_patterns(&getContext());
 
   workspace_transformation_patterns.add<TransformSparseOutput, MoveInvariantComputeOp>(&getContext());
-  indexTree::populateDomainInferencePatterns(&getContext(), workspace_transformation_patterns); //For new index variables
+  CopiedDomainAnalysis& copiedDomains = getAnalysis<CopiedDomainAnalysis>();
+  indexTree::populateDomainInferencePatterns(&getContext(), workspace_transformation_patterns, copiedDomains); //For new index variables
   indexTree::populateDomainConcretizationPatterns(&getContext(), workspace_transformation_patterns);
   mlir::applyPatternsAndFoldGreedily(getOperation(), std::move(workspace_transformation_patterns));
   comet_debug() << __FILE__ << " " << __LINE__ << " ending CompressedWorkspaceTransforms pass \n";


### PR DESCRIPTION
Fixed issues in domain inference pass where temporary tensors were being considered necessary for the iteration of index variables. A byproduct of these fixes was addressing #81. Creates another issue in the fusion optimization that still needs to be addressed. 