### PR TITLE
Fixes for CometPy

### DIFF
--- a/frontends/numpy-scipy/cometpy/comet.py
+++ b/frontends/numpy-scipy/cometpy/comet.py
@@ -603,7 +603,7 @@ class NewVisitor(ast.NodeVisitor):
             elif len(op1['shape']) == 1 and len(op2['shape']) == 2:
                 indices = 'j,jk->k'
             
-            return self.visit_Bin_Einsum_Call(operands, indices, mask, None, 0, False)
+            return self.visit_Bin_Einsum_Call(operands, indices, mask, None, 0, False, {})
 
         self.tcurr +=1
         return self.tcurr-1
@@ -772,7 +772,7 @@ class NewVisitor(ast.NodeVisitor):
                     "operands": [obj]
                 })
 
-    def visit_Bin_Einsum_Call(self, operands, llabels, mask,semiring, beta, no_assign, lbls_to_ilbls = {}):
+    def visit_Bin_Einsum_Call(self, operands, llabels, mask,semiring, beta, no_assign, lbls_to_ilbls):
 
         ops = llabels.split('->')[0].split(',')
         res = list(llabels.split('->')[1])
@@ -1026,7 +1026,7 @@ class NewVisitor(ast.NodeVisitor):
             loperand = operands[0]
             lops = ops[0]
             ret = res
-            tid = self.visit_Bin_Einsum_Call([loperand], lops+"->"+"".join(ret), mask, semiring, no_assign, no_assign)
+            tid = self.visit_Bin_Einsum_Call([loperand], lops+"->"+"".join(ret), mask, semiring, no_assign, no_assign, {})
             lops = "".join(ret)
             return tid
 

--- a/frontends/numpy-scipy/cometpy/comet.py
+++ b/frontends/numpy-scipy/cometpy/comet.py
@@ -772,7 +772,7 @@ class NewVisitor(ast.NodeVisitor):
                     "operands": [obj]
                 })
 
-    def visit_Bin_Einsum_Call(self, operands, llabels, mask,semiring, beta, no_assign):
+    def visit_Bin_Einsum_Call(self, operands, llabels, mask,semiring, beta, no_assign, lbls_to_ilbls = {}):
 
         ops = llabels.split('->')[0].split(',')
         res = list(llabels.split('->')[1])
@@ -787,12 +787,12 @@ class NewVisitor(ast.NodeVisitor):
                     all_dims.append(self.tsemantics[operands[1]]['shape'][i])
         
         lbls_to_dims = {}
-        lbls_to_ilbls = {}
         ilbls_seen = set()
 
         for d,l in zip(all_dims, all_lbls):
             lbls_to_dims[l] = d
-            lbls_to_ilbls[l] = self.get_next_indexlabel_with_val(d)
+            if l not in lbls_to_ilbls:
+                lbls_to_ilbls[l] = self.get_next_indexlabel_with_val(d)
         
         for d,l in zip(all_dims, all_lbls):
             self.reset_indexlabel_with_val(d)
@@ -990,6 +990,7 @@ class NewVisitor(ast.NodeVisitor):
             lops = ops[0]
             saved_no_assign = no_assign
             no_assign = True
+            lbls_to_ilbls = {}
             for i in range(1, len(operands)):
                 all_lbls = list(lops)
                 for l in list(ops[i]):

--- a/frontends/numpy-scipy/cometpy/comet.py
+++ b/frontends/numpy-scipy/cometpy/comet.py
@@ -1072,8 +1072,12 @@ def compile(flags, target:str = "cpu", with_jit=True):
                 type = ret['value_type']
                 return_types.append(type)
 
+            if flags:
+                func_name = func_def.name + flags.replace('-','_').replace(' ','').replace('=','_')
+            else:
+                func_name = func_def.name
             irb = builders.MLIRFunctionBuilder(
-                func_def.name,
+                func_name,
                 input_types=in_types,
                 return_types=return_types,
             ) 
@@ -1160,7 +1164,7 @@ def compile(flags, target:str = "cpu", with_jit=True):
                     new_flags = ' --opt-comp-workspace'
             code = irb.compile()
             # start = time.time()
-            lowering_result = lowering.lower_dialect_with_jit(code, target, None, new_flags,func_def.name, arg_vals, outputs)
+            lowering_result = lowering.lower_dialect_with_jit(code, target, None, new_flags,func_name, arg_vals, outputs)
             # end = time.time()
             # print("Time for JIT", end-start)
             return lowering_result

--- a/frontends/numpy-scipy/cometpy/comet.py
+++ b/frontends/numpy-scipy/cometpy/comet.py
@@ -1017,7 +1017,7 @@ class NewVisitor(ast.NodeVisitor):
                 if i == len(operands) -1 :
                     ret = res
                     no_assign = saved_no_assign
-                tid = self.visit_Bin_Einsum_Call([loperand,operands[i]], lops+","+ops[i]+"->"+"".join(ret), mask, semiring, saved_no_assign, no_assign)
+                tid = self.visit_Bin_Einsum_Call([loperand,operands[i]], lops+","+ops[i]+"->"+"".join(ret), mask, semiring, saved_no_assign, no_assign, lbls_to_ilbls)
                 loperand = tid
                 lops = "".join(ret)
             return tid

--- a/lib/Dialect/TensorAlgebra/Transforms/TCtoTTGT.cpp
+++ b/lib/Dialect/TensorAlgebra/Transforms/TCtoTTGT.cpp
@@ -745,7 +745,7 @@ void TALoweringTTGTPass::runOnOperation()
   auto printFlopFunc = FunctionType::get(ctx, {FloatType::getF64(ctx)}, {});
 
   /// func @getTime() -> f64
-  if (!hasFuncDeclaration(module, "getTime"))
+  if (this->printFlops && !hasFuncDeclaration(module, "getTime"))
   {
     mlir::func::FuncOp func1 = mlir::func::FuncOp::create(function.getLoc(), "getTime", getTimeFunc,
                                                           ArrayRef<NamedAttribute>{});
@@ -754,7 +754,7 @@ void TALoweringTTGTPass::runOnOperation()
   }
 
   /// func @print_flops(%flops) : (f64) -> ()
-  if (!hasFuncDeclaration(module, "print_flops"))
+  if (this->printFlops && !hasFuncDeclaration(module, "print_flops"))
   {
     mlir::func::FuncOp func1 = mlir::func::FuncOp::create(function.getLoc(), "print_flops",
                                                           printFlopFunc, ArrayRef<NamedAttribute>{});


### PR DESCRIPTION
This PR applies the following fixes:

1. Some optimizations rely on consecutive operations re-using the same set of indices. So prefer to reuse the set of indices when possible instead of assigning new ones.
For example, `--convert-tc-to-ttgt --opt-multiop-factorize` will not work for:
```
      %t3 = "ta.mul"(%t0,%t1,%i0,%i1,%i2,%i3,%i4,%i3,%i5,%i1,%i0,%i2,%i4,%i5){MaskType = "None", __alpha__ = 1.000000e+00 : f64, __beta__ = 0.000000e+00 : f64,formats = ["Dense", "Dense", "Dense"],indexing_maps = [affine_map<(d0,d1,d2,d3,d4,d5)->(d0,d1,d2,d3)>, affine_map<(d0,d1,d2,d3,d4,d5)->(d4,d3,d5,d1)>, affine_map<(d0,d1,d2,d3,d4,d5)->(d0,d2,d4,d5)>], operand_segment_sizes = array<i32:1, 1, 12, 0>, semiring = "plusxy_times"} : (tensor<72x72x72x72xf64>,tensor<72x72x72x72xf64>,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel)-> tensor<72x72x72x72xf64>
      %t4 = "ta.mul"(%t3,%t2,%i0,%i1,%i2,%i3,%i1,%i0,%i2,%i3){MaskType = "None", __alpha__ = 1.000000e+00 : f64, __beta__ = 0.000000e+00 : f64,formats = ["Dense", "Dense", "Dense"],indexing_maps = [affine_map<(d0,d1,d2,d3)->(d0,d1,d2,d3)>, affine_map<(d0,d1,d2,d3)->(d1,d0)>, affine_map<(d0,d1,d2,d3)->(d2,d3)>], operand_segment_sizes = array<i32:1, 1, 8, 0>, semiring = "plusxy_times"} : (tensor<72x72x72x72xf64>,tensor<72x72xf64>,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel)-> tensor<72x72xf64>
```
But will work for:
```
      %t3 = "ta.mul"(%t0,%t1,%i0,%i1,%i2,%i3,%i4,%i3,%i5,%i1,%i0,%i2,%i4,%i5){MaskType = "None", __alpha__ = 1.000000e+00 : f64, __beta__ = 0.000000e+00 : f64,formats = ["Dense", "Dense", "Dense"],indexing_maps = [affine_map<(d0,d1,d2,d3,d4,d5)->(d0,d1,d2,d3)>, affine_map<(d0,d1,d2,d3,d4,d5)->(d4,d3,d5,d1)>, affine_map<(d0,d1,d2,d3,d4,d5)->(d0,d2,d4,d5)>], operand_segment_sizes = array<i32:1, 1, 12, 0>, semiring = "plusxy_times"} : (tensor<72x72x72x72xf64>,tensor<72x72x72x72xf64>,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel)-> tensor<72x72x72x72xf64>
      %t4 = "ta.mul"(%t3,%t2,%i0,%i2,%i4,%i5,%i2,%i0,%i4,%i5){MaskType = "None", __alpha__ = 1.000000e+00 : f64, __beta__ = 0.000000e+00 : f64,formats = ["Dense", "Dense", "Dense"],indexing_maps = [affine_map<(d0,d1,d2,d3)->(d0,d1,d2,d3)>, affine_map<(d0,d1,d2,d3)->(d1,d0)>, affine_map<(d0,d1,d2,d3)->(d2,d3)>], operand_segment_sizes = array<i32:1, 1, 8, 0>, semiring = "plusxy_times"} : (tensor<72x72x72x72xf64>,tensor<72x72xf64>,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel,!ta.indexlabel)-> tensor<72x72xf64>
```
Because it detects the indices of the first operand of the second operation being the same as the output of the first operation.

2. Append the optimizations used to the name of generated kernels, so that it's possible to distinguish between same kernel name applied different optimizations.

2. Removed unnecessary inclusion of `print_flops` and `getTime` functions 