### PR TITLE
Adding a Fill and Zero Mask node to the index tree dialect

### DIFF
--- a/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
+++ b/include/comet/Dialect/IndexTree/IR/IndexTreeOps.td
@@ -297,6 +297,24 @@ def IndexTreeDomainIntersectionOp : IndexTreeDomain_Op<"DomainIntersectionOp",
   let results = (outs IndexTree_DomainType:$domain);
 }
 
+def IndexTreeFillMaskOp : IndexTree_Op<"FillMaskOp", [Pure, IndexTreeNodeInterface]>{
+  let summary = "";
+  let description = [{
+  }];
+
+  let arguments = (ins IndexTree_NodeType:$parent, IndexTree_DomainType:$domain, TensorOf<[I1]>:$init);
+  let results = (outs TensorOf<[I1]>:$result);
+}
+
+def IndexTreeZeroMaskOp : IndexTree_Op<"ZeroMaskOp", [Pure, IndexTreeNodeInterface]>{
+  let summary = "";
+  let description = [{
+  }];
+
+  let arguments = (ins IndexTree_NodeType:$parent, IndexTree_DomainType:$domain, TensorOf<[I1]>:$init);
+  let results = (outs TensorOf<[I1]>:$result);
+}
+
 def IndexTreeMaskedDomainOp : IndexTreeDomain_Op<"MaskedDomainOp",
     [Pure, UnknownDomain, ConcreteDomainInterface, IndexTreeNodeInterface]>{
   let summary = "";
@@ -304,9 +322,10 @@ def IndexTreeMaskedDomainOp : IndexTreeDomain_Op<"MaskedDomainOp",
   }];
 
   let arguments = (ins 
-    IndexTree_DomainType:$mask,
+    AnyTypeOf<[TensorOf<[I1]>, IndexTree_DomainType]>:$mask,
     IndexTree_DomainType:$base,
     Optional<Index>:$dim_size);
+
   let results = (outs IndexTree_DomainType:$domain);
 }
 

--- a/include/comet/Dialect/IndexTree/Patterns.h
+++ b/include/comet/Dialect/IndexTree/Patterns.h
@@ -36,6 +36,7 @@ namespace mlir
         void populateDomainConcretizationPatterns(MLIRContext *context, RewritePatternSet &patterns);
         void populateIndexTreeTypeConversionPatterns(MLIRContext *context, RewritePatternSet &patterns, TypeConverter &typeConverter, ConversionTarget& target);
         void populateIndexTreeInliningPatterns(MLIRContext *context, RewritePatternSet &patterns);
+        void populateMaskDomainTransformationPatterns(MLIRContext *context, RewritePatternSet &patterns);
     }
 }
 

--- a/lib/Conversion/TensorAlgebraToSCF/EarlyLowering.cpp
+++ b/lib/Conversion/TensorAlgebraToSCF/EarlyLowering.cpp
@@ -262,7 +262,8 @@ namespace
                         tensorAlgebra::SpTensorGetDimCrd,
                         tensorAlgebra::SpTensorGetVals,
                         tensorAlgebra::SparseTensorConstructOp,
-                        tensorAlgebra::TensorSortOp>();
+                        tensorAlgebra::TensorSortOp,
+                        tensorAlgebra::AllocWorkspaceOp>();
 
       if (failed(applyPartialConversion(function, target, std::move(patterns))))
       {

--- a/lib/Dialect/IndexTree/CMakeLists.txt
+++ b/lib/Dialect/IndexTree/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_dialect_library(COMETIndexTreeDialect
   Transforms/WorkspaceTransforms.cpp
   Transforms/KernelFusion.cpp
   Transforms/DimensionReductionAfterKernelFusion.cpp
+  Transforms/MaskDomainPatterns.cpp
 
   Analysis/CopiedDomainAnalysis.cpp
 

--- a/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
+++ b/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
@@ -475,7 +475,9 @@ struct InferOutputDomains : public OpRewritePattern<IndexTreeSparseTensorOp> {
       if(llvm::isa<indexTree::DomainType>(mask.getType()))
         mask = copyDomain(masked_domain_op.getMask(), rewriter, map, loc, index_vars);
       else {
+        assert(llvm::isa<TensorType>(mask.getType())); // Enforced by verifier create by table gen.
         auto fill_mask_op = mask.getDefiningOp<IndexTreeFillMaskOp>();
+        assert(fill_mask_op && "Currently do not support creating tensors from arbitrary bitmasks.");
         mask = copyDomain(fill_mask_op.getDomain(),  rewriter, map, loc, index_vars);
       }
       copyDomain(masked_domain_op.getBase(), rewriter, map, loc, index_vars);

--- a/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
+++ b/lib/Dialect/IndexTree/Transforms/DomainConcretization.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/IndexedMap.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include "comet/Dialect/IndexTree/IR/IndexTreeDialect.h"
 #include "comet/Dialect/TensorAlgebra/IR/TADialect.h"
@@ -53,7 +54,7 @@ namespace mlir {
 
 struct ConcretizeTensorDomain :  public OpRewritePattern<IndexTreeTensorDomainOp> {
   ConcretizeTensorDomain(MLIRContext *context)
-      : OpRewritePattern<IndexTreeTensorDomainOp>(context, /*benefit=*/1) {}
+      : OpRewritePattern<IndexTreeTensorDomainOp>(context, /*benefit=*/3) {}
 
   mlir::LogicalResult 
   liftAccessOp(mlir::Operation *dependent_op, 
@@ -238,7 +239,7 @@ struct ConcretizeTensorDomain :  public OpRewritePattern<IndexTreeTensorDomainOp
 
 struct SimplifyIntersectionOp : public OpRewritePattern<IndexTreeDomainIntersectionOp> {
   SimplifyIntersectionOp(MLIRContext *context)
-      : OpRewritePattern<IndexTreeDomainIntersectionOp>(context, /*benefit=*/1) {}
+      : OpRewritePattern<IndexTreeDomainIntersectionOp>(context, /*benefit=*/2) {}
 
   mlir::LogicalResult
   matchAndRewrite(IndexTreeDomainIntersectionOp op,
@@ -326,28 +327,35 @@ struct SimplifyIntersectionOp : public OpRewritePattern<IndexTreeDomainIntersect
 
 struct SimplifyMaskOp : public mlir::OpRewritePattern<IndexTreeMaskedDomainOp> {
   SimplifyMaskOp(mlir::MLIRContext *context)
-      : OpRewritePattern<IndexTreeMaskedDomainOp>(context, /*benefit=*/1) {}
+      : OpRewritePattern<IndexTreeMaskedDomainOp>(context, /*benefit=*/2) {}
 
   mlir::LogicalResult
   matchAndRewrite(IndexTreeMaskedDomainOp op,
                   mlir::PatternRewriter &rewriter) const override 
   {
-    Operation* mask = op.getMask().getDefiningOp();
+    Operation* mask_domain;
+    if(llvm::isa<DomainType>(op.getMask().getType())){
+      mask_domain = op.getMask().getDefiningOp();
+    } else {
+      auto fill_mask = op.getMask().getDefiningOp<IndexTreeFillMaskOp>();
+      mask_domain = fill_mask.getDomain().getDefiningOp();
+    }
+    
     Operation* base = op.getBase().getDefiningOp();
-    if(!llvm::isa<ConcreteDomain>(mask) || !llvm::isa<ConcreteDomain>(base)){
+    if(!llvm::isa<ConcreteDomain>(mask_domain) || !llvm::isa<ConcreteDomain>(base)){
       return failure();
     }
 
-    if(llvm::isa<IndexTreeDenseDomainOp>(mask))
+    if(llvm::isa<IndexTreeDenseDomainOp>(mask_domain))
     {
       if(llvm::isa<IndexTreeDenseDomainOp>(base))
       {
-        auto masked_domain = llvm::cast<IndexTreeDenseDomainOp>(mask);
+        auto masked_domain = llvm::cast<IndexTreeDenseDomainOp>(mask_domain);
         auto dense_domain = llvm::cast<IndexTreeDenseDomainOp>(base);
         dense_domain.getTensorsMutable().append(masked_domain.getTensors());
         auto dims = SmallVector<Attribute>(dense_domain.getDims().getAsRange<IntegerAttr>());
         dims.append(masked_domain.getDims().getAsRange<IntegerAttr>().begin(), masked_domain.getDims().getAsRange<IntegerAttr>().end());
-        dense_domain.setDimsAttr(rewriter.getArrayAttr(dims));
+        rewriter.updateRootInPlace(dense_domain, [&](){dense_domain.setDimsAttr(rewriter.getArrayAttr(dims));});
       }
       rewriter.replaceOp(op, op.getBase());
       return success();
@@ -355,7 +363,7 @@ struct SimplifyMaskOp : public mlir::OpRewritePattern<IndexTreeMaskedDomainOp> {
 
     if(llvm::isa<IndexTreeDenseDomainOp>(base))
     {
-      rewriter.replaceOp(op, op.getMask());
+      rewriter.replaceOp(op, mask_domain);
       return success();
     }
 
@@ -369,7 +377,7 @@ struct SimplifyMaskOp : public mlir::OpRewritePattern<IndexTreeMaskedDomainOp> {
 
 struct SimplifyUnionOp : public mlir::OpRewritePattern<IndexTreeDomainUnionOp> {
   SimplifyUnionOp(mlir::MLIRContext *context)
-      : OpRewritePattern<IndexTreeDomainUnionOp>(context, /*benefit=*/1) {}
+      : OpRewritePattern<IndexTreeDomainUnionOp>(context, /*benefit=*/2) {}
 
   mlir::LogicalResult
   matchAndRewrite(IndexTreeDomainUnionOp op,
@@ -435,7 +443,7 @@ struct SimplifyUnionOp : public mlir::OpRewritePattern<IndexTreeDomainUnionOp> {
 
 struct InferOutputDomains : public OpRewritePattern<IndexTreeSparseTensorOp> {
   InferOutputDomains(MLIRContext *context)
-      : OpRewritePattern<IndexTreeSparseTensorOp>(context, /*benefit=*/1) {}
+      : OpRewritePattern<IndexTreeSparseTensorOp>(context, /*benefit=*/2) {}
 
   Value copyDomain(Value domain,
                    mlir::PatternRewriter &rewriter,
@@ -459,14 +467,24 @@ struct InferOutputDomains : public OpRewritePattern<IndexTreeSparseTensorOp> {
         copyDomain(subdomain, rewriter, map, loc, index_vars);
       }
     }
+
     if(llvm::isa<IndexTreeMaskedDomainOp>(domain_op))
     {
       auto masked_domain_op = llvm::cast<IndexTreeMaskedDomainOp>(domain_op);
-      copyDomain(masked_domain_op.getMask(), rewriter, map, loc, index_vars);
+      Value mask = masked_domain_op.getMask();
+      if(llvm::isa<indexTree::DomainType>(mask.getType()))
+        mask = copyDomain(masked_domain_op.getMask(), rewriter, map, loc, index_vars);
+      else {
+        auto fill_mask_op = mask.getDefiningOp<IndexTreeFillMaskOp>();
+        mask = copyDomain(fill_mask_op.getDomain(),  rewriter, map, loc, index_vars);
+      }
       copyDomain(masked_domain_op.getBase(), rewriter, map, loc, index_vars);
-    }
-    
-    if(llvm::isa<IndexTreeSparseDomainOp>(domain_op))
+
+      new_domain = rewriter.clone(*domain_op, map)->getResult(0);
+      auto new_masked_domain = new_domain.getDefiningOp<IndexTreeMaskedDomainOp>();
+      rewriter.updateRootInPlace(new_masked_domain, [&](){new_masked_domain.getMaskMutable().assign(mask);});
+
+    } else if(llvm::isa<IndexTreeSparseDomainOp>(domain_op))
     {
       auto sparse_domain_op = llvm::cast<IndexTreeSparseDomainOp>(domain_op);
 
@@ -606,6 +624,7 @@ struct IndexTreeDomainConcretization : comet::impl::IndexTreeDomainConcretizatio
   void runOnOperation() override {
     mlir::RewritePatternSet domain_concretization_patterns(&getContext());
     indexTree::populateDomainConcretizationPatterns(&getContext(), domain_concretization_patterns);
+    indexTree::populateMaskDomainTransformationPatterns(&getContext(), domain_concretization_patterns);
     if(failed(mlir::applyPatternsAndFoldGreedily(getOperation(), std::move(domain_concretization_patterns)))) {
       return signalPassFailure();
     }

--- a/lib/Dialect/IndexTree/Transforms/MaskDomainPatterns.cpp
+++ b/lib/Dialect/IndexTree/Transforms/MaskDomainPatterns.cpp
@@ -1,0 +1,252 @@
+//
+// Copyright 2022 Battelle Memorial Institute
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+// and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+// and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Index/IR/IndexOps.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/IndexedMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/ScopedPrinter.h"
+
+#include "comet/Dialect/IndexTree/IR/IndexTreeDialect.h"
+#include "comet/Dialect/TensorAlgebra/IR/TADialect.h"
+#include "comet/Dialect/IndexTree/Passes.h"
+#include "comet/Dialect/IndexTree/Patterns.h"
+
+#define DEBUG_TYPE "mask-domain"
+
+using namespace mlir;
+using namespace mlir::indexTree;
+using namespace mlir::tensorAlgebra;
+
+struct MoveInvariantMaskOp : public mlir::OpRewritePattern<IndexTreeFillMaskOp> {
+  MoveInvariantMaskOp(mlir::MLIRContext *context)
+      : OpRewritePattern<IndexTreeFillMaskOp>(context, /*benefit=*/1) {}
+
+    mlir::LogicalResult 
+    liftAccessOp(mlir::Operation *dependent_op, 
+                 IndexTreeIndexToTensorOp access_op,
+                 mlir::PatternRewriter &rewriter ) const {
+      if(access_op->isBeforeInBlock(dependent_op))
+        return success();
+  
+      Value prev_access_value;
+      if((prev_access_value = access_op.getPrevDim()))
+      {
+        if(mlir::failed(
+              liftAccessOp(
+                dependent_op,
+                llvm::cast<IndexTreeIndexToTensorOp>(prev_access_value.getDefiningOp()),
+                rewriter
+              )
+            ))
+          return failure();
+      }
+      rewriter.updateRootInPlace(access_op, [&]() {access_op->moveBefore(dependent_op);});
+      return success();
+    }
+
+  mlir::LogicalResult
+  matchAndRewrite(IndexTreeFillMaskOp op,
+                  mlir::PatternRewriter &rewriter) const override 
+  {
+    if(!llvm::isa<ConcreteDomain>(op.getDomain().getDefiningOp())) {
+      return failure();
+    }
+
+    llvm::ScopedPrinter logger{llvm::dbgs()};
+    LLVM_DEBUG({
+      Operation* domain_op = op.getDomain().getDefiningOp();
+      logger.getOStream() << "\n";
+      logger.startLine() << "Looking at : '" << domain_op->getName() << "'("
+                         << op << ") {\n";
+      logger.indent();
+
+      // If the operation has no regions, just print it here.
+      logger.startLine() << "Concrete domain : '" << domain_op->getName() << "'("<< domain_op << ")\n";
+
+    });
+
+    // We want to find all the indices necessary to compute the mask
+    llvm::SmallDenseSet<Value> used_indices;
+    llvm::SmallVector<Value> work_list;
+    work_list.push_back(op.getDomain());
+    while(!work_list.empty()){
+      Value domain = work_list.back();
+      work_list.pop_back();
+
+      llvm::TypeSwitch<Operation*, void>(domain.getDefiningOp())
+      .Case<IndexTreeDenseDomainOp>([&](IndexTreeDenseDomainOp op) {
+        return;
+      })
+      .Case<IndexTreeSparseDomainOp>([&](IndexTreeSparseDomainOp op) {
+        auto access = op.getParent().getDefiningOp<IndexTreeIndexToTensorOp>();
+        used_indices.insert(access.getIndex());
+        return;
+      })
+      .Case<IndexTreeWorkspaceDomainOp>([&](IndexTreeWorkspaceDomainOp op) {
+        return;
+      })
+      .Case<IndexTreeDomainIntersectionOp>([&](IndexTreeDomainIntersectionOp op) {
+        work_list.append(op.getDomains().begin(), op.getDomains().end());
+        return;
+      })
+      .Case<IndexTreeDomainUnionOp>([&](IndexTreeDomainUnionOp op) {
+        work_list.append(op.getDomains().begin(), op.getDomains().end());
+        return;
+      })
+      .Default([](Operation *op) {
+        assert(false && "IndexNode not given a valid domain");
+        return nullptr;
+      });
+    }
+
+    LLVM_DEBUG({
+      if(used_indices.size() == 0) {
+        op->getParentOp()->print(logger.startLine());
+      }
+
+    });
+
+    // We then move the fill mask op into the highest loop possible
+    Value parent = op.getParent();
+    while(parent != nullptr) {
+      if(used_indices.contains(parent)){
+        break;
+      }
+      parent = parent.getDefiningOp<IndexTreeIndicesOp>().getParent();
+    }
+    assert(parent != nullptr && "Could not find proper nesting for creating mask.");
+    if(parent == op.getParent()) {
+      return failure();
+    }
+
+    // Match success!
+    // We then find the zero op and move it to the same nesting so that the logic remains correct.
+    Value previous_parent = op.getParent();
+    LLVM_DEBUG({
+        op->getParentOp()->print(logger.startLine());
+        logger.startLine() << "\n";
+    });
+    
+    rewriter.updateRootInPlace(op, [&](){
+      Value cur_parent = op.getParent();
+      while(cur_parent != parent) {
+        op->moveBefore(cur_parent.getDefiningOp());
+        cur_parent = llvm::cast<IndexTreeIndicesOp>(cur_parent.getDefiningOp()).getParent();
+      }
+      op.getParentMutable().assign(parent);
+    });
+    if(!op.getDomain().getDefiningOp()->isBeforeInBlock(op)){
+      Operation* domain = op.getDomain().getDefiningOp();
+      rewriter.updateRootInPlace(domain, [&](){domain->moveBefore(op);});
+      IndexTreeSparseDomainOp sparse_domain;
+      if((sparse_domain = llvm::dyn_cast<IndexTreeSparseDomainOp>(domain))){
+        liftAccessOp(sparse_domain, llvm::cast<IndexTreeIndexToTensorOp>(sparse_domain.getParent().getDefiningOp()), rewriter);
+      }
+    }
+
+    IndexTreeZeroMaskOp zero_op = nullptr;
+    for(auto user : previous_parent.getUsers()) {
+      if((zero_op = llvm::dyn_cast<IndexTreeZeroMaskOp>(user)) && zero_op.getInit() == op.getResult()) {
+        rewriter.updateRootInPlace(zero_op, [&](){zero_op.getParentMutable().assign(parent);});
+      }
+    }
+    return success();
+  }
+};
+
+struct CreateFillMaskOp : public mlir::OpRewritePattern<IndexTreeMaskedDomainOp> {
+  CreateFillMaskOp(mlir::MLIRContext *context)
+      : OpRewritePattern<IndexTreeMaskedDomainOp>(context, /*benefit=*/0) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(IndexTreeMaskedDomainOp op,
+                  mlir::PatternRewriter &rewriter) const override 
+  {
+    if(!llvm::isa<DomainType>(op.getMask().getType())) {
+      return failure();
+    }
+
+    if(!llvm::isa<ConcreteDomain>(op.getBase().getDefiningOp())) {
+      return failure();
+    }
+
+    IndexTreeOp tree_op = op->getParentOfType<IndexTreeOp>();
+    if(!tree_op) {
+      return failure();
+    }
+
+    auto mask_domain = op.getMask().getDefiningOp<ConcreteDomain>();
+    if(!mask_domain) {
+      return failure();
+    }
+
+    auto loc = op.getLoc();
+    
+    // Create bit tensor outside of index tree
+    auto cur = rewriter.saveInsertionPoint();
+    rewriter.setInsertionPoint(tree_op);
+    auto bit_tensor_type = RankedTensorType::get({ShapedType::kDynamic}, rewriter.getI1Type());
+    Value f = rewriter.create<arith::ConstantOp>(loc, rewriter.getI1Type(), rewriter.getBoolAttr(false));
+    Value init_bit_tensor = rewriter.create<tensor::SplatOp>(loc, bit_tensor_type, f, mask_domain.getDimensionSize());
+    SmallVector<Value> tree_temps(tree_op.getIntermediates());
+    SmallVector<Type> tree_types(tree_op->getResultTypes());
+    tree_temps.push_back(init_bit_tensor);
+    tree_types.push_back(bit_tensor_type);
+    auto new_op = rewriter.create<IndexTreeOp>(loc, tree_types, tree_op.getInputs(), tree_temps);
+    rewriter.inlineRegionBefore(tree_op.getRegion(), new_op.getRegion(), new_op.getRegion().end());
+
+    rewriter.restoreInsertionPoint(cur);
+    rewriter.updateRootInPlace(new_op, [&](){new_op.getBody()->addArgument(bit_tensor_type, loc);});
+    init_bit_tensor = new_op.getBody()->getArgument(new_op.getBody()->getNumArguments() - 1);
+
+    Value domain = op.getMask();
+    Value mask_tensor = rewriter.create<indexTree::IndexTreeFillMaskOp>(loc, bit_tensor_type, op.getParentNode(), domain, init_bit_tensor);
+    rewriter.updateRootInPlace(op, [&](){op.getMaskMutable().assign(mask_tensor);});
+    indexTree::YieldOp yield = llvm::cast<indexTree::YieldOp>(new_op.getBody()->getTerminator());
+    rewriter.setInsertionPoint(yield);
+    mask_tensor = rewriter.create<indexTree::IndexTreeZeroMaskOp>(loc, bit_tensor_type, op.getParentNode(), domain, mask_tensor);
+    rewriter.updateRootInPlace(new_op, [&](){yield.getResultsMutable().append(ValueRange(mask_tensor));});
+
+    for(unsigned i = 0; i < tree_op.getNumResults(); i++){
+      rewriter.replaceAllUsesWith(tree_op.getResult(i), new_op.getResult(i));
+    }
+    rewriter.eraseOp(tree_op);
+
+    return success();
+  }
+};
+
+void indexTree::populateMaskDomainTransformationPatterns(MLIRContext *context, RewritePatternSet &patterns) {
+  patterns.add<CreateFillMaskOp, MoveInvariantMaskOp>(context);
+}

--- a/lib/Dialect/IndexTree/Transforms/SymbolicCompute.cpp
+++ b/lib/Dialect/IndexTree/Transforms/SymbolicCompute.cpp
@@ -34,6 +34,7 @@
 #include <cstdint>
 
 #include "comet/Dialect/IndexTree/IR/IndexTreeDialect.h"
+#include "comet/Dialect/IndexTree/Patterns.h"
 #include "comet/Dialect/TensorAlgebra/IR/TADialect.h"
 #include "comet/Dialect/IndexTree/Passes.h"
 
@@ -343,6 +344,7 @@ struct IndexTreeSymbolicComputePass : comet::impl::IndexTreeSymbolicComputePassB
   void runOnOperation() {
     mlir::RewritePatternSet sp_output_patterns(&getContext());
     sp_output_patterns.add<CreateSymbolicTree>(&getContext());
+    indexTree::populateMaskDomainTransformationPatterns(&getContext(), sp_output_patterns);
     mlir::applyPatternsAndFoldGreedily(getOperation(), std::move(sp_output_patterns));
   }
 };


### PR DESCRIPTION
Part of a series of commits to implement using a bit tensor to co-iterate over two sparse domains. This commit implements a FillMaskOp and ZeroMaskOp that can be added to the index tree to create the bit tensor. As part of the index tree, they can be manipulated. We use this to move the creation of the mask into the outer most loop possible. This PR fixes #88.
The performance of TC with masking after this commit: 
```
bcsstk17,0.012047
cant,0.156279
consph,0.212944
cop20k_A,0.118532
pdb1HYS,0.313485
rma10,0.087574
scircuit,0.019193
shipsec1,0.241516
```
and from main:
```
bcsstk17,0.012336
cant,0.173369
consph,0.220049
cop20k_A,0.107967
pdb1HYS,0.28059
rma10,0.091136
scircuit,0.020206
shipsec1,0.305356
```