### PR TITLE
Introduce interoperability with cupy, pytorch, numba

### DIFF
--- a/frontends/numpy-scipy/integration_tests/ops/gpu/test_gpu_eltwise_add_dense_matrix_interop.py
+++ b/frontends/numpy-scipy/integration_tests/ops/gpu/test_gpu_eltwise_add_dense_matrix_interop.py
@@ -1,0 +1,25 @@
+import time
+import numpy as np
+import scipy as sp
+import cupy
+from cometpy import comet
+from conftest import gpu
+
+def run_numpy(A,B,C):
+	C[:] = A+B 
+
+@comet.compile(flags=None, target="gpu")
+def run_comet_with_jit(A,B,C):
+	C[:] = A+B 
+
+@gpu
+def test_gpu_eltwise_add_dense_matrix_interop():
+    A = np.full([4, 4], 2.2,  dtype=float)
+    B = np.full([4, 4], 3.4,  dtype=float)
+    C = np.full([4, 4], 0.0,  dtype=float)
+    Ad = cupy.asarray(A)
+    Bd = cupy.asarray(B)
+    Cd = cupy.asarray(C)
+    run_numpy(A,B,C)
+    run_comet_with_jit(Ad,Bd,Cd)
+    np.testing.assert_almost_equal(Cd.get(), C)

--- a/include/comet/Conversion/PrepareGpuHost/Passes.td
+++ b/include/comet/Conversion/PrepareGpuHost/Passes.td
@@ -7,7 +7,13 @@ def PrepareGpuHost: Pass<"prepare-gpu-host", "mlir::ModuleOp"> {
        let summary = "Prepare GPU host";
        let description = [{}];
        let constructor = "mlir::comet::createPrepareGpuHostPass()";
-
+       
+       let options = [
+              Option<"generateAllocsAndTransfers", "generate-allocs-and-transfers",
+                     "bool", "true",
+                     "Whether to generate allocations and transfers">
+       ];
+       
        let dependentDialects = ["mlir::gpu::GPUDialect", "mlir::func::FuncDialect", "mlir::LLVM::LLVMDialect"];
 }
 #endif

--- a/include/comet/Conversion/PrepareGpuHost/PrepareGpuHostPass.h
+++ b/include/comet/Conversion/PrepareGpuHost/PrepareGpuHostPass.h
@@ -13,6 +13,7 @@ namespace comet {
 
 
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createPrepareGpuHostPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createPrepareGpuHostPass(bool generateAllocsAndTransfers);
 
 } // namespace triton
 } // namespace mlir

--- a/lib/Conversion/GpuUtils/GpuUtils.cpp
+++ b/lib/Conversion/GpuUtils/GpuUtils.cpp
@@ -268,7 +268,7 @@ mlir::LogicalResult specializeGpuHost(mlir::OpBuilder& builder, mlir::ModuleOp m
             LLVM::linkage::Linkage::Private);
       }
       builder.create<mlir::func::CallOp>(
-          launchOp->getLoc(), vendor_prefix+"LaunchKernel", TypeRange(),
+          launchOp->getLoc(), vendor_prefix+"LaunchKernelMLIR", TypeRange(),
           ValueRange({launchOp.getGridSizeX(), launchOp.getGridSizeY(),
                       launchOp.getGridSizeZ(), launchOp.getBlockSizeX(),
                       launchOp.getBlockSizeY(), launchOp.getBlockSizeZ(),
@@ -388,7 +388,7 @@ void declare_vendor_funcs(OpBuilder& builder, ModuleOp modOp, std::string vendor
     builder.getIndexType(), builder.getIntegerType(32)},
     {});
   auto cudaLaunchKernel = builder.create<mlir::func::FuncOp>(
-    builder.getUnknownLoc(), vendor_prefix+"LaunchKernel", cudaLaunchKernelT);
+    builder.getUnknownLoc(), vendor_prefix+"LaunchKernelMLIR", cudaLaunchKernelT);
   cudaLaunchKernel.setVisibility(mlir::SymbolTable::Visibility::Private);
   modOp.push_back(cudaLaunchKernel);
 

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -47,6 +47,7 @@ set(LIBS
 if(ENABLE_NVIDIA_GPU_BACKEND)
   if(${CUDAToolkit_FOUND})
     set(LIBS ${LIBS} CUDA::cuda_driver)
+    set(LIBS ${LIBS} CUDA::cudart)
   endif()
 endif()
 

--- a/lib/ExecutionEngine/HipGpuUtils.cpp
+++ b/lib/ExecutionEngine/HipGpuUtils.cpp
@@ -22,15 +22,13 @@ hipModule_t hipModule = NULL;
 // char* moduleImg = NULL;
 
 void initHipCtx(char *moduleImg) {
-  HIP_CHECK(hipInit(0));
-
   if (moduleImg) {
+    HIP_CHECK(hipFree(NULL)); 
     HIP_CHECK(hipModuleLoadData(&hipModule, moduleImg));
   }
 }
 
 template <typename T> int64_t HipMalloc(int64_t size) {
-  initHipCtx(NULL);
   hipDeviceptr_t device_ptr;
   HIP_CHECK(hipMalloc(&device_ptr, size * sizeof(T)));
 
@@ -72,7 +70,6 @@ HipMallocI32(int64_t size) {
 }
 
 extern "C" __attribute__((visibility("default"))) void HipFree(int64_t ptr) {
-  initHipCtx(NULL);
 
   // printf("Freeing memory\n");
   HIP_CHECK(hipFree((void *)ptr));
@@ -82,7 +79,6 @@ extern "C" __attribute__((visibility("default"))) void HipFree(int64_t ptr) {
 template <typename T>
 void HipMemcpy(int64_t device, void *ptr, void *aligned_ptr, int64_t offset,
                int64_t size, int64_t stride, int64_t direction) {
-  initHipCtx(NULL);
 
   // printf("Memcpy memory of size: %ld\n", size);
 

--- a/lib/ExecutionEngine/HipGpuUtils.cpp
+++ b/lib/ExecutionEngine/HipGpuUtils.cpp
@@ -141,7 +141,7 @@ const int64_t MAX_NUM_BLOCKS_Y = 65535;
 const int64_t MAX_NUM_BLOCKS_Z = 65535;
 
 extern "C" __attribute__((visibility("default"))) void
-HipLaunchKernel(int64_t realblocksX, int64_t realblocksY, int64_t realblocksZ,
+HipLaunchKernelMLIR(int64_t realblocksX, int64_t realblocksY, int64_t realblocksZ,
                 int64_t tritonBlockX, int64_t tritonBlockY,
                 int64_t tritonBlockZ, void *ptr, void *aligned_ptr,
                 int64_t offset, int64_t size, int64_t stride, char *kernel,


### PR DESCRIPTION
This PR enables cometpy to use ndarrays created from other runtimes like cupy, pytorch or numba.
Thus, data allocated on the device from any of these can be referenced with zero copy from cometpy.

We also introduce the ability to mutate data in-place for cometpy. For example:

`` C[:] = A + B``

will store the result of  ``A+B`` into an existing ndarray `C` instead of creating a new one.
