### PR TITLE
Gpu remove redundant copies

### DIFF
--- a/lib/Conversion/BlockedGpuToTriton/BlockedGpuToTriton.cpp
+++ b/lib/Conversion/BlockedGpuToTriton/BlockedGpuToTriton.cpp
@@ -103,7 +103,8 @@ class ConvertGpuFuncToTritonFunc : public OpConversionPattern<mlir::gpu::GPUFunc
         rewriter.create<func::ReturnOp>(gpuFunc.getLoc());
         newFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                            rewriter.getUnitAttr());
-        
+        newFunc.setArgAttrsAttr(gpuFunc.getArgAttrsAttr());
+                
         return success();
     }
 

--- a/lib/Conversion/PrepareGpuHost/PrepareGpuHost.cpp
+++ b/lib/Conversion/PrepareGpuHost/PrepareGpuHost.cpp
@@ -1,4 +1,7 @@
 #include "comet/Conversion/PrepareGpuHost/PrepareGpuHostPass.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -26,6 +29,7 @@ public:
 
     std::map<std::string, Value> funcs;
     std::map<std::string, std::string> gpu_to_triton_kernel;
+    std::map<std::string, func::FuncOp> gpu_name_to_funcOp;
     std::map<std::string, triton::FuncOp> triton_name_to_triton_func_op;
     auto gpuModules = modOp.getOps<gpu::GPUModuleOp>();
     for(auto gpuModuleOp: gpuModules)
@@ -33,17 +37,20 @@ public:
         auto funcOps = gpuModuleOp.getOps<mlir::func::FuncOp>();
         for(func::FuncOp funcOp: llvm::make_early_inc_range(funcOps))
         {
+            std::map<size_t, std::vector<Attribute>> argsToSet;
             if(!funcOp->hasAttr(gpu::GPUDialect::getKernelFuncAttrName()))
             {
                 continue;
             }
             builder.setInsertionPoint(funcOp);
             SmallVector<Type, 4> newTypes;
-            for(auto argType: funcOp.getArgumentTypes())
+            for(auto arg: funcOp.getArguments())
             {
+                auto argType = arg.getType();
                 newTypes.push_back(argType);
                 if(MemRefType rankedType = dyn_cast<mlir::MemRefType>(argType))
                 {
+                    argsToSet[newTypes.size() - 1] = {funcOp.getArgAttr(arg.getArgNumber(), "gpu.read"), funcOp.getArgAttr(arg.getArgNumber(), "gpu.write")};
                     if(rankedType.hasRank())
                     {
                         newTypes.push_back(builder.getIndexType());
@@ -71,6 +78,18 @@ public:
             builder.create<func::ReturnOp>(funcOp.getLoc());
             newFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                                 builder.getUnitAttr());
+            for(auto [argNumber, attrs]: argsToSet)
+            {
+                if(attrs[0])
+                {
+                    newFunc.setArgAttr(argNumber, "gpu.read", attrs[0]);
+                }
+                if(attrs[1])
+                {
+                    newFunc.setArgAttr(argNumber, "gpu.write", attrs[1]);
+                }
+            }
+            gpu_name_to_funcOp[funcOp.getName().str()] = newFunc;
             funcOp->erase();
         }
     }
@@ -185,14 +204,22 @@ public:
                 if (mlir::gpu::LaunchFuncOp launchOp =
                         dyn_cast<mlir::gpu::LaunchFuncOp>(use.getOwner())) {
                     builder.setInsertionPoint(launchOp);
-                    builder.create<mlir::gpu::MemcpyOp>(launchOp->getLoc(), TypeRange(),
-                                                        ValueRange(),
-                                                        gpuAlloc.getMemref(), alloc);
+                    int offset = launchOp->getNumOperands() - launchOp.getNumKernelOperands();
+                    int operNum = use.getOperandNumber() - offset;
+                    if(gpu_name_to_funcOp[launchOp.getKernelName().str()].getArgAttr(operNum, "gpu.read"))
+                    {
+                        builder.create<mlir::gpu::MemcpyOp>(launchOp->getLoc(), TypeRange(),
+                                                            ValueRange(),
+                                                            gpuAlloc.getMemref(), alloc);
+                    }
                     use.set(gpuAlloc.getMemref());
                     builder.setInsertionPointAfter(launchOp);
-                    builder.create<mlir::gpu::MemcpyOp>(launchOp->getLoc(), TypeRange(),
-                                                        ValueRange(), alloc,
-                                                        gpuAlloc.getMemref());
+                    if(gpu_name_to_funcOp[launchOp.getKernelName().str()].getArgAttr(operNum, "gpu.write"))
+                    {
+                                            builder.create<mlir::gpu::MemcpyOp>(launchOp->getLoc(), TypeRange(),
+                                                                                ValueRange(), alloc,
+                                                                                gpuAlloc.getMemref());
+                    }
                 }
             }
         }

--- a/lib/Conversion/PrepareGpuHost/PrepareGpuHost.cpp
+++ b/lib/Conversion/PrepareGpuHost/PrepareGpuHost.cpp
@@ -267,7 +267,6 @@ public:
             {
                 if(!copyIn & gpuCopy->hasAttr("gpu.read"))
                 {
-                    // gpuCopy.dump();
                     gpuCopy->erase();
                 }
                 else if(gpuCopy->hasAttr("gpu.read"))
@@ -308,7 +307,6 @@ public:
             }
             else // Unknown operation, be conservative
             {
-                effects[i]->dump();
                 copyIn = true;
                 if(!copyDelete.empty())
                 {
@@ -319,7 +317,6 @@ public:
 
         for(auto toDelete: copyDelete)
         {
-            // toDelete->dump();
             toDelete->erase();
         }
     }


### PR DESCRIPTION
This PR partially resolves #112
- First, the GPU kernel is examined and all load/store operations on any of its inputs are detected. Thus, we can track which arguments read, write or read-write the data provided by the host. As a result, the host can decide which data really need to be transferred to/from the device.
- Second, we add a simple and conservative heuristic that tracks memrefs used in each GPU kernel launch operation and tries to remove redundant data transfers when the host does not access the data used/ produced by a previous kernel execution. (Assuming a single GPU)